### PR TITLE
refactor: modular crypto architecture with real PRF/PRG (Milestone 0-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### SEH Prefix Consistency Proofs (Issue #13)
+- **Issue #13**: Strengthened SEH prefix consistency proofs with real Merkle paths
+  - `SehDigest` now stores full `tree_layers` for proof generation
+  - `SehProof` redesigned with proper structure:
+    - `prefix_len`: Length of shared prefix
+    - `prefix_subtree_hash`: Hash of subtree covering the prefix
+    - `path_to_root1/2`: Merkle paths from subtree to each root
+  - Added `MerklePath` struct for authentication paths
+  - `consis_prove()`: Generates real Merkle path proofs
+  - `consis_verify()`: Verifies paths reconstruct to both roots
+  - Correctly detects when prefixes differ (verification fails)
+- Added 6 new prefix consistency tests:
+  - `test_seh_digest_stores_tree_layers`
+  - `test_seh_prefix_consistency_same_values`
+  - `test_seh_prefix_consistency_shared_prefix`
+  - `test_seh_prefix_consistency_different_prefix`
+  - `test_seh_prefix_consistency_empty`
+  - `test_seh_proof_contains_merkle_paths`
+- Total: 53 tests pass
+
 ### Error Handling, Wire Indices & Benchmarks (Milestone 4)
 - **Issue #15**: Changed `evaluate()` to return `Result<_, LiOError>` instead of panicking
   - Added `LiOError::MacVerificationFailed { gate_index, table_index }` variant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,64 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Error Handling, Wire Indices & Benchmarks (Milestone 4)
+- **Issue #15**: Changed `evaluate()` to return `Result<_, LiOError>` instead of panicking
+  - Added `LiOError::MacVerificationFailed { gate_index, table_index }` variant
+  - Added `LiOError::LabelMismatch { gate_index }` variant
+  - Added `LiOError::SehVerificationFailed` variant
+  - Added `evaluate_unchecked()` convenience method that panics on failure
+  - Updated all tests to use `.unwrap()` or pattern matching
+- **Issue #14**: Upgraded wire indices from `u8` to `u16`
+  - `Gate` struct now uses `u16` for `output_wire`, `input_wire_a`, `input_wire_b`
+  - Supports circuits up to 65,536 wires (previously 256)
+  - Updated `padding.rs` to use `u16` throughout
+  - Added test `test_large_circuit_over_256_wires` with 300-wire circuit
+- **Issue #16**: Added Criterion benchmarks
+  - `benches/obfuscation.rs`: obfuscation time vs gates, wires, size overhead
+  - `benches/evaluation.rs`: evaluation time, SEH verification, correctness check
+  - Run with `cargo bench --bench obfuscation` or `cargo bench --bench evaluation`
+- Total: 47 tests pass
+
+### SEH, SmallObf & PRF Puncturing Integration (Milestone 3)
+- SEH fully integrated into ObfuscatedLiO:
+  - `seh_params`, `seh_ciphertexts`, `seh_committed_values` fields stored
+  - `verify_seh()` method validates all SEH openings against digest
+  - `seh_opening(position)` returns SEH opening for inspection
+  - `evaluate_with_seh_check(input)` verifies SEH before evaluation
+  - `seh_consistency_proof/verify` for prefix consistency between obfuscations
+- SmallObf integrated per-gate:
+  - `GateGadget::to_bytecode_program()` converts gates to bytecode
+  - `StubSmallObf::eval()` extended with gate gadget opcodes (0x10-0x17)
+  - `ObfuscatedGate::gadget_obf` field contains obfuscated gate gadget
+  - Gate evaluation now goes through SmallObf interface
+- PRF puncturing exposed for security analysis:
+  - `ObfuscatedGate::prf_input_for_entry()` returns exact PRF input bits
+  - Test demonstrates punctured key blocks correct input while allowing others
+- Added 8 new tests for SEH, SmallObf, and PRF functionality
+- Total: 46 tests pass
+
+### Real FHE Integration & Wire Labels (Milestone 2)
+- Added real LWE-based FHE backend via `tfhe` crate (optional, `tfhe-backend` feature)
+  - `TfheFhe` wrapper implementing `FheScheme` trait
+  - `DefaultFhe` type alias switching between `StubFhe` and `TfheFhe` based on feature
+- Generalized SEH over FHE backends:
+  - `GenericSeh<F>` works with any `FheScheme` implementation
+  - `SehOpening<Ct>` is now generic over ciphertext type
+  - `CiphertextBytes` trait for serializing ciphertexts for Merkle hashing
+  - `DefaultSeh` alias uses `DefaultFhe`
+- Implemented proper per-wire labels as required by the paper:
+  - `WireLabels` struct with two random 32-byte labels (L_i^0, L_i^1) per wire
+  - Gate tables now encrypt output labels keyed by input labels
+  - PRF input built from full label bytes (256+256 bits) plus gate index
+- Integrated MAC verification into evaluation:
+  - MACs are now verified during `ObfuscatedGate::evaluate()`
+  - Panics on tampered table entries (integrity check)
+  - Added test `test_lio_mac_verification_detects_tampering`
+- Cargo features:
+  - `stub-fhe` (default): Fast stub FHE for development
+  - `tfhe-backend`: Real LWE-based FHE (slow compile)
+- Updated documentation in `lib.rs` and `lio.rs` with implementation status
+
 ### Core Library Refactoring (Milestone 0 & 1)
 - Refactored stub types into modular architecture with proper trait abstractions
 - Created `src/circuit.rs` - Circuit/Gate/ControlFunction with evaluation and random generation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Core Library Refactoring (Milestone 0 & 1)
+- Refactored stub types into modular architecture with proper trait abstractions
+- Created `src/circuit.rs` - Circuit/Gate/ControlFunction with evaluation and random generation
+- Created `src/crypto/` module with cryptographic primitive traits:
+  - `fhe.rs` - FHE trait with StubFhe implementation
+  - `prf.rs` - GGM-based Puncturable PRF implementation (real crypto!)
+  - `prg.rs` - SHA-256 based PRG implementation (real crypto!)
+  - `seh.rs` - Somewhere Extractable Hash trait with StubSeh
+  - `obf.rs` - Small-circuit iO trait (documented assumption)
+- Created `src/lio.rs` - Local iO implementation with:
+  - Real PRF-based wire encryption (GGM tree)
+  - Real MAC generation using PRG
+  - Encrypted truth tables per gate
+  - Correct evaluation verified against plaintext circuits
+- Created `src/padding.rs` - Circuit padding with routing networks
+- Added `src/lib.rs` compatibility module for proven_stealth_mix
+- All 34 unit tests pass, 7 integration tests pass
+
 ### Honeypot Demo Improvements
 - Added `simple_hash` to WASM matching Noir circuit commitment scheme
 - Added `generate_noir_witness()` for generating Noir-compatible witness JSON

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,35 @@ categories = ["cryptography"]
 rand = "0.8"
 sha2 = "0.10"
 
+# Real LWE-based FHE backend (heavyweight, gated behind feature)
+# Note: tfhe 1.x has breaking API changes; upgrade requires code migration
+tfhe = { version = "0.8", optional = true, default-features = false, features = ["boolean"] }
+
+# Serialization for tfhe ciphertexts in SEH
+bincode = { version = "1.3", optional = true }
+serde = { version = "1.0", optional = true }
+
 [dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[features]
+# Use stub FHE by default (fast compile, no real crypto)
+default = ["stub-fhe"]
+
+# Stub FHE backend (development/testing)
+stub-fhe = []
+
+# Real tfhe-based FHE backend; enables LWE-based encryption
+tfhe-backend = ["tfhe", "bincode", "serde"]
 
 [[example]]
 name = "integration_test"
 path = "examples/integration_test.rs"
+
+[[bench]]
+name = "obfuscation"
+harness = false
+
+[[bench]]
+name = "evaluation"
+harness = false

--- a/benches/evaluation.rs
+++ b/benches/evaluation.rs
@@ -1,0 +1,105 @@
+//! Benchmarks for LiO evaluation performance
+//!
+//! Run with: `cargo bench --bench evaluation`
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use ma_dai_shi_io::circuit::Circuit;
+use ma_dai_shi_io::lio::{LiO, LiOParams};
+
+fn bench_evaluate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("evaluation");
+
+    for num_gates in [5, 10, 25, 50] {
+        let num_wires = (num_gates + 2).min(64);
+        let circuit = Circuit::random_r57(num_wires, num_gates);
+        let lio = LiO::new(LiOParams::default());
+        let obf = lio.obfuscate(&circuit).unwrap();
+
+        group.throughput(Throughput::Elements(num_gates as u64));
+        group.bench_with_input(BenchmarkId::new("gates", num_gates), &obf, |b, obf| {
+            let mut input = 0usize;
+            b.iter(|| {
+                input = (input + 1) % (1 << num_wires.min(16));
+                obf.evaluate(input).unwrap()
+            })
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_evaluate_with_seh_check(c: &mut Criterion) {
+    let mut group = c.benchmark_group("evaluation_seh");
+
+    for num_gates in [5, 10, 25] {
+        let num_wires = num_gates + 2;
+        let circuit = Circuit::random_r57(num_wires, num_gates);
+        let lio = LiO::new(LiOParams::default());
+        let obf = lio.obfuscate(&circuit).unwrap();
+
+        group.bench_with_input(
+            BenchmarkId::new("gates_with_seh", num_gates),
+            &obf,
+            |b, obf| {
+                let mut input = 0usize;
+                b.iter(|| {
+                    input = (input + 1) % (1 << num_wires.min(16));
+                    obf.evaluate_with_seh_check(input).unwrap()
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_verify_seh(c: &mut Criterion) {
+    let mut group = c.benchmark_group("seh_verification");
+
+    for num_gates in [5, 10, 25] {
+        let num_wires = num_gates + 2;
+        let circuit = Circuit::random_r57(num_wires, num_gates);
+        let lio = LiO::new(LiOParams::default());
+        let obf = lio.obfuscate(&circuit).unwrap();
+
+        group.bench_with_input(
+            BenchmarkId::new("wires", num_wires),
+            &obf,
+            |b, obf| b.iter(|| obf.verify_seh()),
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_correctness(c: &mut Criterion) {
+    let mut group = c.benchmark_group("correctness_check");
+
+    let num_gates = 10;
+    let num_wires = 8;
+    let circuit = Circuit::random_r57(num_wires, num_gates);
+    let lio = LiO::new(LiOParams::default());
+    let obf = lio.obfuscate(&circuit).unwrap();
+
+    group.bench_function("obf_vs_plaintext", |b| {
+        let mut input = 0usize;
+        b.iter(|| {
+            input = (input + 1) % (1 << num_wires);
+            let obf_result = obf.evaluate(input).unwrap();
+            let plain_result = circuit.evaluate(input);
+            assert_eq!(obf_result, plain_result);
+            obf_result
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_evaluate,
+    bench_evaluate_with_seh_check,
+    bench_verify_seh,
+    bench_correctness
+);
+criterion_main!(benches);

--- a/benches/obfuscation.rs
+++ b/benches/obfuscation.rs
@@ -1,0 +1,79 @@
+//! Benchmarks for LiO obfuscation performance
+//!
+//! Run with: `cargo bench --bench obfuscation`
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use ma_dai_shi_io::circuit::Circuit;
+use ma_dai_shi_io::lio::{LiO, LiOParams};
+
+fn bench_obfuscate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("obfuscation");
+
+    for num_gates in [5, 10, 25, 50] {
+        let num_wires = (num_gates + 2).min(64);
+        let circuit = Circuit::random_r57(num_wires, num_gates);
+
+        group.throughput(Throughput::Elements(num_gates as u64));
+        group.bench_with_input(
+            BenchmarkId::new("gates", num_gates),
+            &circuit,
+            |b, circuit| {
+                b.iter(|| {
+                    let lio = LiO::new(LiOParams::default());
+                    lio.obfuscate(circuit).unwrap()
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_obfuscate_varying_wires(c: &mut Criterion) {
+    let mut group = c.benchmark_group("obfuscation_wires");
+
+    let num_gates = 10;
+    for num_wires in [8, 16, 32, 64] {
+        let circuit = Circuit::random_r57(num_wires, num_gates);
+
+        group.bench_with_input(
+            BenchmarkId::new("wires", num_wires),
+            &circuit,
+            |b, circuit| {
+                b.iter(|| {
+                    let lio = LiO::new(LiOParams::default());
+                    lio.obfuscate(circuit).unwrap()
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_obfuscated_size(c: &mut Criterion) {
+    let mut group = c.benchmark_group("obfuscated_size");
+
+    for num_gates in [5, 10, 25] {
+        let num_wires = num_gates + 2;
+        let circuit = Circuit::random_r57(num_wires, num_gates);
+        let lio = LiO::new(LiOParams::default());
+        let obf = lio.obfuscate(&circuit).unwrap();
+
+        group.bench_with_input(
+            BenchmarkId::new("size_bytes", num_gates),
+            &obf,
+            |b, obf| b.iter(|| obf.size_bytes()),
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_obfuscate,
+    bench_obfuscate_varying_wires,
+    bench_obfuscated_size
+);
+criterion_main!(benches);

--- a/examples/integration_test.rs
+++ b/examples/integration_test.rs
@@ -21,7 +21,7 @@ use ma_dai_shi_io::{
     obfuscate_auto, obfuscate_optimized, estimate_overhead, estimate_overhead_optimized, pad,
     Circuit,
 };
-use ma_dai_shi_io::stub::proven_stealth_mix;
+use ma_dai_shi_io::compat::proven_stealth_mix;
 
 use std::time::Instant;
 

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -1,0 +1,245 @@
+//! Circuit representation for Ma-Dai-Shi iO
+//!
+//! Defines the core circuit abstractions used throughout the obfuscation pipeline.
+//!
+//! # Wire Index Limitation
+//!
+//! **Note:** Wire indices are stored as `u8`, limiting circuits to a maximum of
+//! 256 wires. This is sufficient for the current demo/testing purposes but would
+//! need to be upgraded to `u16` or `usize` for production use with larger circuits.
+
+use rand::Rng;
+
+/// Boolean gate control functions
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+pub enum ControlFunction {
+    /// Constant false
+    F,
+    /// Logical AND
+    And,
+    /// Logical XOR
+    Xor,
+    /// Logical OR
+    Or,
+    /// Logical NAND
+    Nand,
+    /// Logical NOR
+    Nor,
+    /// Logical XNOR
+    Xnor,
+    /// a AND (NOT b)
+    AndNot,
+}
+
+impl ControlFunction {
+    /// Evaluate the gate function on two boolean inputs
+    pub fn evaluate(&self, a: bool, b: bool) -> bool {
+        match self {
+            Self::F => false,
+            Self::And => a && b,
+            Self::Xor => a ^ b,
+            Self::Or => a || b,
+            Self::Nand => !(a && b),
+            Self::Nor => !(a || b),
+            Self::Xnor => !(a ^ b),
+            Self::AndNot => a && !b,
+        }
+    }
+
+    /// Returns all available control functions
+    pub fn all() -> &'static [ControlFunction] {
+        &[
+            Self::F,
+            Self::And,
+            Self::Xor,
+            Self::Or,
+            Self::Nand,
+            Self::Nor,
+            Self::Xnor,
+            Self::AndNot,
+        ]
+    }
+}
+
+/// A single gate in a boolean circuit
+#[derive(Clone, Debug)]
+pub struct Gate {
+    /// Wire index where output is written
+    pub output_wire: u8,
+    /// First input wire index
+    pub input_wire_a: u8,
+    /// Second input wire index
+    pub input_wire_b: u8,
+    /// The boolean function computed by this gate
+    pub control_function: ControlFunction,
+}
+
+impl Gate {
+    /// Create a new gate
+    pub fn new(output: u8, a: u8, b: u8, func: ControlFunction) -> Self {
+        Self {
+            output_wire: output,
+            input_wire_a: a,
+            input_wire_b: b,
+            control_function: func,
+        }
+    }
+}
+
+/// A boolean circuit as a sequence of gates
+#[derive(Clone, Debug)]
+pub struct Circuit {
+    /// Ordered list of gates (topologically sorted)
+    pub gates: Vec<Gate>,
+    /// Total number of wires in the circuit
+    pub num_wires: usize,
+}
+
+impl Circuit {
+    /// Create a new circuit
+    pub fn new(gates: Vec<Gate>, num_wires: usize) -> Self {
+        Self { gates, num_wires }
+    }
+
+    /// Evaluate the circuit on a given input
+    ///
+    /// Input bits are encoded in the least significant bits of `input`.
+    /// Output is similarly encoded in the result.
+    pub fn evaluate(&self, input: usize) -> usize {
+        let mut wires = vec![false; self.num_wires];
+        for i in 0..self.num_wires {
+            wires[i] = (input >> i) & 1 == 1;
+        }
+        for gate in &self.gates {
+            let a = wires[gate.input_wire_a as usize];
+            let b = wires[gate.input_wire_b as usize];
+            wires[gate.output_wire as usize] = gate.control_function.evaluate(a, b);
+        }
+        let mut output = 0usize;
+        for (i, &w) in wires.iter().enumerate() {
+            if w {
+                output |= 1 << i;
+            }
+        }
+        output
+    }
+
+    /// Generate a random circuit (for testing)
+    ///
+    /// Uses a subset of control functions similar to R57 circuits.
+    pub fn random_r57(num_wires: usize, num_gates: usize) -> Self {
+        let mut rng = rand::thread_rng();
+        let funcs = [
+            ControlFunction::And,
+            ControlFunction::Xor,
+            ControlFunction::Or,
+            ControlFunction::Nand,
+        ];
+        let gates: Vec<Gate> = (0..num_gates)
+            .map(|_| {
+                let out = rng.gen_range(0..num_wires) as u8;
+                let a = rng.gen_range(0..num_wires) as u8;
+                let b = rng.gen_range(0..num_wires) as u8;
+                let func = funcs[rng.gen_range(0..funcs.len())];
+                Gate::new(out, a, b, func)
+            })
+            .collect();
+        Self { gates, num_wires }
+    }
+
+    /// Create an identity circuit that doesn't modify any wires
+    pub fn identity(num_wires: usize) -> Self {
+        Self {
+            gates: vec![],
+            num_wires,
+        }
+    }
+
+    /// Get the number of gates in this circuit
+    pub fn size(&self) -> usize {
+        self.gates.len()
+    }
+}
+
+/// Proof of equivalence between two circuits
+///
+/// In the full Ma-Dai-Shi construction, this would be an EF (Equivalence Framework)
+/// proof that can be verified by a polynomial-time verifier.
+#[derive(Clone, Debug)]
+pub struct EquivalenceProof {
+    /// Hash of the first circuit
+    pub circuit_a_hash: [u8; 32],
+    /// Hash of the second circuit
+    pub circuit_b_hash: [u8; 32],
+    /// Proof steps (symbolic representation)
+    pub proof_steps: Vec<String>,
+}
+
+impl EquivalenceProof {
+    /// Create a dummy proof (for testing/development)
+    ///
+    /// This should only be used when the circuits are known to be equivalent.
+    pub fn dummy(circuit: &Circuit) -> Self {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(format!("{:?}", circuit.gates));
+        let hash: [u8; 32] = hasher.finalize().into();
+        Self {
+            circuit_a_hash: hash,
+            circuit_b_hash: hash,
+            proof_steps: vec!["identity".to_string()],
+        }
+    }
+
+    /// Get the proof size in bytes (for parameter estimation)
+    pub fn size(&self) -> usize {
+        64 + self.proof_steps.len() * 64
+    }
+}
+
+/// EF (Equivalence Framework) proof wrapper
+#[derive(Clone, Debug)]
+pub struct EFProof {
+    /// Size of the proof in bytes
+    pub proof_size: usize,
+}
+
+/// Convert an EquivalenceProof to an EFProof for size estimation
+pub fn to_ef_proof(proof: &EquivalenceProof) -> EFProof {
+    EFProof {
+        proof_size: proof.proof_steps.len() * 64 + 128,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_control_functions() {
+        assert!(!ControlFunction::F.evaluate(true, true));
+        assert!(ControlFunction::And.evaluate(true, true));
+        assert!(!ControlFunction::And.evaluate(true, false));
+        assert!(ControlFunction::Xor.evaluate(true, false));
+        assert!(!ControlFunction::Xor.evaluate(true, true));
+        assert!(ControlFunction::Or.evaluate(false, true));
+        assert!(ControlFunction::Nand.evaluate(true, false));
+    }
+
+    #[test]
+    fn test_circuit_evaluate() {
+        let gates = vec![Gate::new(2, 0, 1, ControlFunction::And)];
+        let circuit = Circuit::new(gates, 3);
+
+        assert_eq!(circuit.evaluate(0b11), 0b111);
+        assert_eq!(circuit.evaluate(0b01), 0b001);
+        assert_eq!(circuit.evaluate(0b10), 0b010);
+    }
+
+    #[test]
+    fn test_random_circuit() {
+        let circuit = Circuit::random_r57(8, 10);
+        assert_eq!(circuit.gates.len(), 10);
+        assert_eq!(circuit.num_wires, 8);
+    }
+}

--- a/src/crypto/fhe.rs
+++ b/src/crypto/fhe.rs
@@ -1,0 +1,208 @@
+//! Fully Homomorphic Encryption (FHE) trait and stub implementation
+//!
+//! The FHE scheme is used in the SEH construction for encrypting wire labels
+//! and supporting homomorphic evaluation of small verification circuits.
+//!
+//! ## Security
+//!
+//! Security is based on the Learning With Errors (LWE) problem.
+//! A production implementation should use a well-audited library like `tfhe`.
+
+use std::fmt::Debug;
+
+/// FHE scheme parameters
+#[derive(Clone, Debug)]
+pub struct FheParams {
+    /// Security parameter (bits)
+    pub lambda: usize,
+    /// Plaintext modulus (typically 2 for boolean FHE)
+    pub plaintext_modulus: u64,
+}
+
+impl Default for FheParams {
+    fn default() -> Self {
+        Self {
+            lambda: 128,
+            plaintext_modulus: 2,
+        }
+    }
+}
+
+/// An FHE ciphertext
+#[derive(Clone, Debug)]
+pub struct FheCiphertext {
+    /// Ciphertext data (opaque bytes in real implementation)
+    pub data: Vec<u8>,
+}
+
+impl FheCiphertext {
+    /// Create a dummy ciphertext (for stub implementation)
+    pub fn dummy(bit: bool) -> Self {
+        Self {
+            data: vec![if bit { 1 } else { 0 }],
+        }
+    }
+}
+
+/// FHE public key
+#[derive(Clone, Debug)]
+pub struct FhePublicKey {
+    pub data: Vec<u8>,
+}
+
+/// FHE secret key
+#[derive(Clone, Debug)]
+pub struct FheSecretKey {
+    pub data: Vec<u8>,
+}
+
+/// Trait for Fully Homomorphic Encryption schemes
+///
+/// This trait abstracts over different FHE implementations (e.g., tfhe, concrete).
+pub trait FheScheme: Clone + Debug {
+    /// The ciphertext type
+    type Ciphertext: Clone + Debug;
+
+    /// The public key type
+    type PublicKey: Clone + Debug;
+
+    /// The secret key type
+    type SecretKey: Clone + Debug;
+
+    /// Generate a fresh key pair
+    fn keygen(&self, params: &FheParams) -> (Self::SecretKey, Self::PublicKey);
+
+    /// Encrypt a single bit
+    fn encrypt_bit(&self, pk: &Self::PublicKey, bit: bool) -> Self::Ciphertext;
+
+    /// Decrypt a ciphertext to a single bit
+    fn decrypt_bit(&self, sk: &Self::SecretKey, ct: &Self::Ciphertext) -> bool;
+
+    /// Homomorphically evaluate AND gate
+    fn eval_and(
+        &self,
+        pk: &Self::PublicKey,
+        a: &Self::Ciphertext,
+        b: &Self::Ciphertext,
+    ) -> Self::Ciphertext;
+
+    /// Homomorphically evaluate XOR gate
+    fn eval_xor(
+        &self,
+        pk: &Self::PublicKey,
+        a: &Self::Ciphertext,
+        b: &Self::Ciphertext,
+    ) -> Self::Ciphertext;
+
+    /// Homomorphically evaluate NOT gate
+    fn eval_not(&self, pk: &Self::PublicKey, a: &Self::Ciphertext) -> Self::Ciphertext;
+
+    /// Homomorphically evaluate OR gate (derived from AND and NOT)
+    fn eval_or(
+        &self,
+        pk: &Self::PublicKey,
+        a: &Self::Ciphertext,
+        b: &Self::Ciphertext,
+    ) -> Self::Ciphertext {
+        let not_a = self.eval_not(pk, a);
+        let not_b = self.eval_not(pk, b);
+        let not_result = self.eval_and(pk, &not_a, &not_b);
+        self.eval_not(pk, &not_result)
+    }
+}
+
+/// Stub FHE implementation for development
+///
+/// WARNING: This is NOT cryptographically secure. It's a placeholder
+/// that maintains the correct interface while real FHE is integrated.
+#[derive(Clone, Debug)]
+pub struct StubFhe;
+
+impl FheScheme for StubFhe {
+    type Ciphertext = FheCiphertext;
+    type PublicKey = FhePublicKey;
+    type SecretKey = FheSecretKey;
+
+    fn keygen(&self, _params: &FheParams) -> (Self::SecretKey, Self::PublicKey) {
+        (
+            FheSecretKey {
+                data: vec![0u8; 32],
+            },
+            FhePublicKey {
+                data: vec![0u8; 32],
+            },
+        )
+    }
+
+    fn encrypt_bit(&self, _pk: &Self::PublicKey, bit: bool) -> Self::Ciphertext {
+        FheCiphertext::dummy(bit)
+    }
+
+    fn decrypt_bit(&self, _sk: &Self::SecretKey, ct: &Self::Ciphertext) -> bool {
+        ct.data.first().map(|&b| b != 0).unwrap_or(false)
+    }
+
+    fn eval_and(
+        &self,
+        _pk: &Self::PublicKey,
+        a: &Self::Ciphertext,
+        b: &Self::Ciphertext,
+    ) -> Self::Ciphertext {
+        let a_bit = a.data.first().map(|&b| b != 0).unwrap_or(false);
+        let b_bit = b.data.first().map(|&b| b != 0).unwrap_or(false);
+        FheCiphertext::dummy(a_bit && b_bit)
+    }
+
+    fn eval_xor(
+        &self,
+        _pk: &Self::PublicKey,
+        a: &Self::Ciphertext,
+        b: &Self::Ciphertext,
+    ) -> Self::Ciphertext {
+        let a_bit = a.data.first().map(|&b| b != 0).unwrap_or(false);
+        let b_bit = b.data.first().map(|&b| b != 0).unwrap_or(false);
+        FheCiphertext::dummy(a_bit ^ b_bit)
+    }
+
+    fn eval_not(&self, _pk: &Self::PublicKey, a: &Self::Ciphertext) -> Self::Ciphertext {
+        let a_bit = a.data.first().map(|&b| b != 0).unwrap_or(false);
+        FheCiphertext::dummy(!a_bit)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stub_fhe_roundtrip() {
+        let fhe = StubFhe;
+        let params = FheParams::default();
+        let (sk, pk) = fhe.keygen(&params);
+
+        let ct_true = fhe.encrypt_bit(&pk, true);
+        let ct_false = fhe.encrypt_bit(&pk, false);
+
+        assert!(fhe.decrypt_bit(&sk, &ct_true));
+        assert!(!fhe.decrypt_bit(&sk, &ct_false));
+    }
+
+    #[test]
+    fn test_stub_fhe_homomorphic_ops() {
+        let fhe = StubFhe;
+        let params = FheParams::default();
+        let (sk, pk) = fhe.keygen(&params);
+
+        let ct_a = fhe.encrypt_bit(&pk, true);
+        let ct_b = fhe.encrypt_bit(&pk, false);
+
+        let ct_and = fhe.eval_and(&pk, &ct_a, &ct_b);
+        assert!(!fhe.decrypt_bit(&sk, &ct_and));
+
+        let ct_xor = fhe.eval_xor(&pk, &ct_a, &ct_b);
+        assert!(fhe.decrypt_bit(&sk, &ct_xor));
+
+        let ct_or = fhe.eval_or(&pk, &ct_a, &ct_b);
+        assert!(fhe.decrypt_bit(&sk, &ct_or));
+    }
+}

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -32,6 +32,6 @@ pub use obf::{BytecodeProgram, GateGadget, ObfuscatedBytecode, SmallObf, StubSma
 pub use prf::{GgmPrf, MacPrf, PuncturablePrf, PuncturedKey, WirePrf};
 pub use prg::{Prg, Sha256Prg};
 pub use seh::{
-    CiphertextBytes, DefaultSeh, GenericSeh, SehDigest, SehOpening, SehParams, SehProof,
-    SehScheme, StubSeh, StubSehOpening,
+    CiphertextBytes, DefaultSeh, GenericSeh, MerklePath, SehDigest, SehOpening, SehParams,
+    SehProof, SehScheme, StubSeh, StubSehOpening,
 };

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,0 +1,32 @@
+//! Cryptographic primitives for Ma-Dai-Shi iO
+//!
+//! This module defines the cryptographic building blocks required for the
+//! Local iO (LiO) construction from §5 of the Ma-Dai-Shi paper.
+//!
+//! ## Required Primitives
+//!
+//! 1. **FHE (Fully Homomorphic Encryption)** - LWE-based encryption supporting
+//!    homomorphic evaluation of small circuits.
+//!
+//! 2. **SEH (Somewhere Extractable Hash)** - Merkle-tree-like hash with FHE
+//!    ciphertexts, supporting prefix consistency proofs.
+//!
+//! 3. **Puncturable PRF** - GGM-tree-based PRF that can be punctured at
+//!    specific points for the security reduction.
+//!
+//! 4. **PRG (Pseudorandom Generator)** - For key stretching and mask generation.
+//!
+//! 5. **Small-Circuit iO** - Obfuscator for fixed, small gadget circuits
+//!    (treated as an assumption in this implementation).
+
+pub mod fhe;
+pub mod obf;
+pub mod prf;
+pub mod prg;
+pub mod seh;
+
+pub use fhe::{FheCiphertext, FheParams, FheScheme, StubFhe};
+pub use obf::{SmallObf, StubSmallObf};
+pub use prf::{GgmPrf, MacPrf, PuncturablePrf, PuncturedKey, WirePrf};
+pub use prg::{Prg, Sha256Prg};
+pub use seh::{SehDigest, SehOpening, SehParams, SehProof, SehScheme, StubSeh};

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -25,8 +25,13 @@ pub mod prf;
 pub mod prg;
 pub mod seh;
 
-pub use fhe::{FheCiphertext, FheParams, FheScheme, StubFhe};
-pub use obf::{SmallObf, StubSmallObf};
+pub use fhe::{DefaultFhe, FheCiphertext, FheParams, FheScheme, StubFhe};
+#[cfg(feature = "tfhe-backend")]
+pub use fhe::{TfheCiphertextWrapper, TfheFhe, TfhePublicKey, TfheSecretKey};
+pub use obf::{BytecodeProgram, GateGadget, ObfuscatedBytecode, SmallObf, StubSmallObf};
 pub use prf::{GgmPrf, MacPrf, PuncturablePrf, PuncturedKey, WirePrf};
 pub use prg::{Prg, Sha256Prg};
-pub use seh::{SehDigest, SehOpening, SehParams, SehProof, SehScheme, StubSeh};
+pub use seh::{
+    CiphertextBytes, DefaultSeh, GenericSeh, SehDigest, SehOpening, SehParams, SehProof,
+    SehScheme, StubSeh, StubSehOpening,
+};

--- a/src/crypto/obf.rs
+++ b/src/crypto/obf.rs
@@ -1,0 +1,230 @@
+//! Small-circuit indistinguishability obfuscation
+//!
+//! This module provides the `SmallObf` trait for obfuscating small, fixed gadget circuits.
+//! In the Ma-Dai-Shi construction, each gate is turned into a small universal circuit
+//! that is then obfuscated.
+//!
+//! ## Security Assumption
+//!
+//! This implementation treats small-circuit iO as an **explicit cryptographic assumption**.
+//! The stub implementation uses conventional encryption (NOT cryptographically iO).
+//!
+//! A production implementation would require:
+//! - A concrete iO candidate (e.g., from functional encryption or multilinear maps)
+//! - Or integration with an external iO implementation
+//!
+//! ## Paper Reference
+//!
+//! See §5.2 of Ma-Dai-Shi 2025 for the gate gadget construction.
+
+use std::fmt::Debug;
+
+/// Trait for small-circuit indistinguishability obfuscation
+///
+/// WARNING: Implementing true iO is an open research problem.
+/// This trait defines the interface; actual security depends on the implementation.
+pub trait SmallObf: Clone + Debug {
+    /// The type of programs that can be obfuscated
+    type Program: Clone + Debug;
+
+    /// The type of obfuscated programs
+    type Obfuscated: Clone + Debug;
+
+    /// Obfuscate a program
+    ///
+    /// The obfuscated program should compute the same function as the original,
+    /// but reveal nothing about the implementation details.
+    fn obfuscate(&self, prog: &Self::Program) -> Self::Obfuscated;
+
+    /// Evaluate an obfuscated program on input
+    fn eval(&self, obf: &Self::Obfuscated, input: &[u8]) -> Vec<u8>;
+}
+
+/// A simple bytecode program (for stub implementation)
+#[derive(Clone, Debug)]
+pub struct BytecodeProgram {
+    /// The bytecode instructions
+    pub instructions: Vec<u8>,
+    /// Number of input bytes
+    pub input_size: usize,
+    /// Number of output bytes
+    pub output_size: usize,
+}
+
+impl BytecodeProgram {
+    /// Create a new bytecode program
+    pub fn new(instructions: Vec<u8>, input_size: usize, output_size: usize) -> Self {
+        Self {
+            instructions,
+            input_size,
+            output_size,
+        }
+    }
+
+    /// Create a program that computes XOR of all input bytes
+    pub fn xor_all(input_size: usize) -> Self {
+        Self {
+            instructions: vec![0x01],
+            input_size,
+            output_size: 1,
+        }
+    }
+
+    /// Create a program that copies input to output
+    pub fn identity(size: usize) -> Self {
+        Self {
+            instructions: vec![0x00],
+            input_size: size,
+            output_size: size,
+        }
+    }
+}
+
+/// An "obfuscated" bytecode program (stub implementation)
+#[derive(Clone, Debug)]
+pub struct ObfuscatedBytecode {
+    /// Encrypted bytecode (in real iO, this would be truly obfuscated)
+    pub encrypted_data: Vec<u8>,
+    /// Encryption key (in real iO, this would be incorporated into the obfuscation)
+    pub key: [u8; 32],
+    /// Program metadata
+    pub input_size: usize,
+    pub output_size: usize,
+}
+
+/// Stub small-circuit obfuscator
+///
+/// WARNING: This is NOT cryptographically secure iO.
+/// It uses simple XOR encryption as a placeholder.
+/// This maintains the correct interface while real iO research progresses.
+#[derive(Clone, Debug, Default)]
+pub struct StubSmallObf;
+
+impl SmallObf for StubSmallObf {
+    type Program = BytecodeProgram;
+    type Obfuscated = ObfuscatedBytecode;
+
+    fn obfuscate(&self, prog: &Self::Program) -> Self::Obfuscated {
+        use rand::RngCore;
+
+        let mut key = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut key);
+
+        let encrypted_data: Vec<u8> = prog
+            .instructions
+            .iter()
+            .enumerate()
+            .map(|(i, &b)| b ^ key[i % 32])
+            .collect();
+
+        ObfuscatedBytecode {
+            encrypted_data,
+            key,
+            input_size: prog.input_size,
+            output_size: prog.output_size,
+        }
+    }
+
+    fn eval(&self, obf: &Self::Obfuscated, input: &[u8]) -> Vec<u8> {
+        let decrypted: Vec<u8> = obf
+            .encrypted_data
+            .iter()
+            .enumerate()
+            .map(|(i, &b)| b ^ obf.key[i % 32])
+            .collect();
+
+        match decrypted.first() {
+            Some(0x00) => input.to_vec(),
+            Some(0x01) => {
+                let xor_result = input.iter().fold(0u8, |acc, &b| acc ^ b);
+                vec![xor_result]
+            }
+            _ => vec![0u8; obf.output_size],
+        }
+    }
+}
+
+/// Gate gadget for LiO construction
+///
+/// Represents the "universal gate" circuit that is obfuscated in the LiO scheme.
+/// For a 2-input boolean gate, this encapsulates:
+/// - Input wire labels (encrypted)
+/// - Output wire label computation
+/// - MAC verification
+#[derive(Clone, Debug)]
+pub struct GateGadget {
+    /// Gate type (AND, XOR, etc.)
+    pub gate_type: u8,
+    /// Input wire indices
+    pub input_wires: (usize, usize),
+    /// Output wire index
+    pub output_wire: usize,
+}
+
+impl GateGadget {
+    /// Gate type constants
+    pub const AND: u8 = 0;
+    pub const XOR: u8 = 1;
+    pub const OR: u8 = 2;
+    pub const NAND: u8 = 3;
+
+    /// Create a new gate gadget
+    pub fn new(gate_type: u8, input_wires: (usize, usize), output_wire: usize) -> Self {
+        Self {
+            gate_type,
+            input_wires,
+            output_wire,
+        }
+    }
+
+    /// Evaluate the gate on plaintext inputs
+    pub fn evaluate(&self, a: bool, b: bool) -> bool {
+        match self.gate_type {
+            Self::AND => a && b,
+            Self::XOR => a ^ b,
+            Self::OR => a || b,
+            Self::NAND => !(a && b),
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stub_obf_identity() {
+        let obf = StubSmallObf;
+        let prog = BytecodeProgram::identity(4);
+
+        let obfuscated = obf.obfuscate(&prog);
+        let input = vec![1, 2, 3, 4];
+        let output = obf.eval(&obfuscated, &input);
+
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_stub_obf_xor() {
+        let obf = StubSmallObf;
+        let prog = BytecodeProgram::xor_all(3);
+
+        let obfuscated = obf.obfuscate(&prog);
+        let input = vec![0b1010, 0b1100, 0b0011];
+        let output = obf.eval(&obfuscated, &input);
+
+        assert_eq!(output, vec![0b1010 ^ 0b1100 ^ 0b0011]);
+    }
+
+    #[test]
+    fn test_gate_gadget_evaluate() {
+        let and_gate = GateGadget::new(GateGadget::AND, (0, 1), 2);
+        assert!(and_gate.evaluate(true, true));
+        assert!(!and_gate.evaluate(true, false));
+
+        let xor_gate = GateGadget::new(GateGadget::XOR, (0, 1), 2);
+        assert!(xor_gate.evaluate(true, false));
+        assert!(!xor_gate.evaluate(true, true));
+    }
+}

--- a/src/crypto/prf.rs
+++ b/src/crypto/prf.rs
@@ -1,0 +1,249 @@
+//! Puncturable PRF implementation using GGM tree
+//!
+//! The GGM (Goldreich-Goldwasser-Micali) construction builds a PRF from a PRG.
+//! It supports efficient puncturing: given a key and a point x, produce a
+//! "punctured key" that can evaluate on all inputs except x.
+//!
+//! ## Usage in Ma-Dai-Shi
+//!
+//! Two PRFs are used:
+//! - `PRF_m` (WirePrf): generates wire encryption masks
+//! - `PRF_σ` (MacPrf): generates MAC keys/tags
+
+use super::prg::{Prg, Sha256Prg};
+use sha2::{Digest, Sha256};
+
+/// A punctured key that can evaluate everywhere except at the punctured point
+#[derive(Clone, Debug)]
+pub struct PuncturedKey {
+    /// Sibling seeds along the path to the punctured point
+    pub sibling_seeds: Vec<[u8; 32]>,
+    /// The punctured point (as bit string)
+    pub punctured_point: Vec<bool>,
+    /// Depth of the GGM tree
+    pub depth: usize,
+}
+
+/// Trait for Puncturable PRFs
+pub trait PuncturablePrf: Clone {
+    /// The key type
+    type Key: Clone;
+
+    /// Generate a fresh PRF key
+    fn keygen(&self) -> Self::Key;
+
+    /// Evaluate the PRF at a point
+    fn eval(&self, key: &Self::Key, input: &[bool]) -> [u8; 32];
+
+    /// Puncture the key at a specific point
+    ///
+    /// Returns a punctured key that can evaluate on all inputs except the given point.
+    fn puncture(&self, key: &Self::Key, point: &[bool]) -> PuncturedKey;
+
+    /// Evaluate using a punctured key
+    ///
+    /// Returns None if the input equals the punctured point.
+    fn eval_punctured(&self, pkey: &PuncturedKey, input: &[bool]) -> Option<[u8; 32]>;
+}
+
+/// GGM-tree based puncturable PRF
+#[derive(Clone, Debug)]
+pub struct GgmPrf {
+    prg: Sha256Prg,
+    depth: usize,
+}
+
+impl GgmPrf {
+    /// Create a new GGM PRF with specified depth
+    pub fn new(depth: usize) -> Self {
+        Self {
+            prg: Sha256Prg,
+            depth,
+        }
+    }
+
+    /// Walk the GGM tree from root to leaf
+    fn tree_walk(&self, root: &[u8; 32], path: &[bool]) -> [u8; 32] {
+        let mut current = *root;
+
+        for &bit in path.iter().take(self.depth) {
+            let (left, right) = self.prg.expand_double(&current);
+            current = if bit { right } else { left };
+        }
+
+        current
+    }
+}
+
+impl PuncturablePrf for GgmPrf {
+    type Key = [u8; 32];
+
+    fn keygen(&self) -> Self::Key {
+        use rand::RngCore;
+        let mut key = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut key);
+        key
+    }
+
+    fn eval(&self, key: &Self::Key, input: &[bool]) -> [u8; 32] {
+        let padded: Vec<bool> = input
+            .iter()
+            .copied()
+            .chain(std::iter::repeat(false))
+            .take(self.depth)
+            .collect();
+
+        let leaf_seed = self.tree_walk(key, &padded);
+
+        let mut hasher = Sha256::new();
+        hasher.update(leaf_seed);
+        hasher.update(b"output");
+        hasher.finalize().into()
+    }
+
+    fn puncture(&self, key: &Self::Key, point: &[bool]) -> PuncturedKey {
+        let padded: Vec<bool> = point
+            .iter()
+            .copied()
+            .chain(std::iter::repeat(false))
+            .take(self.depth)
+            .collect();
+
+        let mut sibling_seeds = Vec::with_capacity(self.depth);
+        let mut current = *key;
+
+        for &bit in padded.iter() {
+            let (left, right) = self.prg.expand_double(&current);
+
+            if bit {
+                sibling_seeds.push(left);
+                current = right;
+            } else {
+                sibling_seeds.push(right);
+                current = left;
+            }
+        }
+
+        PuncturedKey {
+            sibling_seeds,
+            punctured_point: padded,
+            depth: self.depth,
+        }
+    }
+
+    fn eval_punctured(&self, pkey: &PuncturedKey, input: &[bool]) -> Option<[u8; 32]> {
+        let padded: Vec<bool> = input
+            .iter()
+            .copied()
+            .chain(std::iter::repeat(false))
+            .take(self.depth)
+            .collect();
+
+        if padded == pkey.punctured_point {
+            return None;
+        }
+
+        let mut diverge_idx = None;
+        for (i, (&input_bit, &punct_bit)) in padded.iter().zip(&pkey.punctured_point).enumerate() {
+            if input_bit != punct_bit {
+                diverge_idx = Some(i);
+                break;
+            }
+        }
+
+        let diverge_idx = diverge_idx?;
+
+        let mut current = pkey.sibling_seeds[diverge_idx];
+
+        for &bit in padded.iter().skip(diverge_idx + 1) {
+            let (left, right) = self.prg.expand_double(&current);
+            current = if bit { right } else { left };
+        }
+
+        let mut hasher = Sha256::new();
+        hasher.update(current);
+        hasher.update(b"output");
+        Some(hasher.finalize().into())
+    }
+}
+
+/// Wire encryption PRF (PRF_m in the paper)
+pub type WirePrf = GgmPrf;
+
+/// MAC key PRF (PRF_σ in the paper)
+pub type MacPrf = GgmPrf;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ggm_prf_deterministic() {
+        let prf = GgmPrf::new(8);
+        let key = prf.keygen();
+        let input = vec![true, false, true, false];
+
+        let out1 = prf.eval(&key, &input);
+        let out2 = prf.eval(&key, &input);
+
+        assert_eq!(out1, out2);
+    }
+
+    #[test]
+    fn test_ggm_prf_different_inputs() {
+        let prf = GgmPrf::new(8);
+        let key = prf.keygen();
+
+        let out1 = prf.eval(&key, &[true, false]);
+        let out2 = prf.eval(&key, &[false, true]);
+
+        assert_ne!(out1, out2);
+    }
+
+    #[test]
+    fn test_ggm_puncture_blocks_point() {
+        let prf = GgmPrf::new(4);
+        let key = prf.keygen();
+        let punct_point = vec![true, false, true, false];
+
+        let pkey = prf.puncture(&key, &punct_point);
+
+        assert!(prf.eval_punctured(&pkey, &punct_point).is_none());
+    }
+
+    #[test]
+    fn test_ggm_puncture_allows_other_points() {
+        let prf = GgmPrf::new(4);
+        let key = prf.keygen();
+        let punct_point = vec![true, false, true, false];
+        let other_point = vec![false, false, true, false];
+
+        let pkey = prf.puncture(&key, &punct_point);
+
+        let normal_eval = prf.eval(&key, &other_point);
+        let punct_eval = prf.eval_punctured(&pkey, &other_point).unwrap();
+
+        assert_eq!(normal_eval, punct_eval);
+    }
+
+    #[test]
+    fn test_ggm_puncture_consistency() {
+        let prf = GgmPrf::new(8);
+        let key = prf.keygen();
+        let punct_point = vec![true, true, false, false];
+
+        let pkey = prf.puncture(&key, &punct_point);
+
+        for i in 0..16u8 {
+            let input: Vec<bool> = (0..4).map(|j| (i >> j) & 1 == 1).collect();
+
+            if input == punct_point {
+                assert!(prf.eval_punctured(&pkey, &input).is_none());
+            } else {
+                let normal = prf.eval(&key, &input);
+                let punct = prf.eval_punctured(&pkey, &input).unwrap();
+                assert_eq!(normal, punct);
+            }
+        }
+    }
+}

--- a/src/crypto/prf.rs
+++ b/src/crypto/prf.rs
@@ -151,7 +151,9 @@ impl PuncturablePrf for GgmPrf {
             }
         }
 
-        let diverge_idx = diverge_idx?;
+        // Safe: we already returned None if padded == punctured_point,
+        // so there must be a divergence point
+        let diverge_idx = diverge_idx.expect("divergence point must exist");
 
         let mut current = pkey.sibling_seeds[diverge_idx];
 

--- a/src/crypto/prg.rs
+++ b/src/crypto/prg.rs
@@ -1,0 +1,108 @@
+//! Pseudorandom Generator (PRG) implementation
+//!
+//! Used for key stretching and mask generation in the LiO construction.
+//! The PRG is modeled as a keyed hash function (BLAKE3 or SHA-256).
+
+use sha2::{Digest, Sha256};
+
+/// Trait for Pseudorandom Generators
+pub trait Prg {
+    /// Expand a seed into a longer output
+    fn expand(&self, seed: &[u8], output_len: usize) -> Vec<u8>;
+
+    /// Generate two child seeds from a parent seed (for GGM tree)
+    fn expand_double(&self, seed: &[u8; 32]) -> ([u8; 32], [u8; 32]) {
+        let output = self.expand(seed, 64);
+        let mut left = [0u8; 32];
+        let mut right = [0u8; 32];
+        left.copy_from_slice(&output[..32]);
+        right.copy_from_slice(&output[32..]);
+        (left, right)
+    }
+}
+
+/// SHA-256 based PRG implementation
+///
+/// Uses HKDF-style expansion: PRG(seed, i) = H(seed || i) for each block.
+#[derive(Clone, Debug, Default)]
+pub struct Sha256Prg;
+
+impl Prg for Sha256Prg {
+    fn expand(&self, seed: &[u8], output_len: usize) -> Vec<u8> {
+        let mut output = Vec::with_capacity(output_len);
+        let mut counter = 0u64;
+
+        while output.len() < output_len {
+            let mut hasher = Sha256::new();
+            hasher.update(seed);
+            hasher.update(counter.to_le_bytes());
+            let block = hasher.finalize();
+
+            let remaining = output_len - output.len();
+            let to_copy = remaining.min(32);
+            output.extend_from_slice(&block[..to_copy]);
+
+            counter += 1;
+        }
+
+        output
+    }
+}
+
+/// Generate a random seed
+pub fn random_seed() -> [u8; 32] {
+    use rand::RngCore;
+    let mut seed = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut seed);
+    seed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_prg_deterministic() {
+        let prg = Sha256Prg;
+        let seed = [0u8; 32];
+
+        let out1 = prg.expand(&seed, 64);
+        let out2 = prg.expand(&seed, 64);
+
+        assert_eq!(out1, out2);
+    }
+
+    #[test]
+    fn test_prg_different_seeds() {
+        let prg = Sha256Prg;
+        let seed1 = [0u8; 32];
+        let mut seed2 = [0u8; 32];
+        seed2[0] = 1;
+
+        let out1 = prg.expand(&seed1, 64);
+        let out2 = prg.expand(&seed2, 64);
+
+        assert_ne!(out1, out2);
+    }
+
+    #[test]
+    fn test_prg_expand_double() {
+        let prg = Sha256Prg;
+        let seed = [42u8; 32];
+
+        let (left, right) = prg.expand_double(&seed);
+
+        assert_ne!(left, right);
+        assert_ne!(left, seed);
+    }
+
+    #[test]
+    fn test_prg_output_length() {
+        let prg = Sha256Prg;
+        let seed = [0u8; 32];
+
+        assert_eq!(prg.expand(&seed, 16).len(), 16);
+        assert_eq!(prg.expand(&seed, 64).len(), 64);
+        assert_eq!(prg.expand(&seed, 100).len(), 100);
+    }
+}

--- a/src/crypto/seh.rs
+++ b/src/crypto/seh.rs
@@ -1,0 +1,342 @@
+//! Somewhere Extractable Hash (SEH) implementation
+//!
+//! Based on the Hubáček-Wichs construction, adapted for Ma-Dai-Shi.
+//! SEH is a Merkle-tree-like structure over FHE ciphertexts that supports:
+//!
+//! - `Hash`: Compute a digest of a sequence of values
+//! - `Open`: Create an opening proof for a specific position
+//! - `Verify`: Check that an opening is valid
+//! - `ConsisP/ConsisV`: Prove/verify prefix consistency between two digests
+//!
+//! ## Security
+//!
+//! Relies on LWE-based FHE for the "somewhere extractable" property.
+
+use super::fhe::{FheCiphertext, FheParams, FheScheme, StubFhe};
+use sha2::{Digest, Sha256};
+
+/// SEH parameters
+#[derive(Clone, Debug)]
+pub struct SehParams {
+    /// Number of elements to hash
+    pub num_elements: usize,
+    /// Tree arity (typically 2 for binary tree)
+    pub arity: usize,
+    /// FHE parameters for ciphertext encryption
+    pub fhe_params: FheParams,
+}
+
+impl Default for SehParams {
+    fn default() -> Self {
+        Self {
+            num_elements: 16,
+            arity: 2,
+            fhe_params: FheParams::default(),
+        }
+    }
+}
+
+/// SEH digest (root hash)
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SehDigest {
+    /// Root hash value
+    pub root: [u8; 32],
+    /// Height of the Merkle tree
+    pub height: usize,
+}
+
+/// SEH opening for a specific position
+#[derive(Clone, Debug)]
+pub struct SehOpening {
+    /// Position being opened
+    pub position: usize,
+    /// Leaf value (FHE ciphertext of the element)
+    pub leaf_ciphertext: FheCiphertext,
+    /// Sibling hashes along the path to the root
+    pub sibling_hashes: Vec<[u8; 32]>,
+}
+
+/// SEH prefix consistency proof
+#[derive(Clone, Debug)]
+pub struct SehProof {
+    /// Common prefix nodes
+    pub common_nodes: Vec<[u8; 32]>,
+    /// Depth at which the proofs diverge
+    pub diverge_depth: usize,
+}
+
+/// Trait for Somewhere Extractable Hash schemes
+pub trait SehScheme: Clone {
+    /// FHE scheme used for ciphertext leaves
+    type Fhe: FheScheme;
+
+    /// Generate SEH parameters
+    fn gen(&self, params: &SehParams) -> SehParams;
+
+    /// Hash a sequence of boolean values
+    fn hash(&self, params: &SehParams, values: &[bool]) -> (SehDigest, Vec<FheCiphertext>);
+
+    /// Open the hash at a specific position
+    fn open(
+        &self,
+        params: &SehParams,
+        values: &[bool],
+        ciphertexts: &[FheCiphertext],
+        position: usize,
+    ) -> SehOpening;
+
+    /// Verify an opening against a digest
+    fn verify(&self, params: &SehParams, digest: &SehDigest, opening: &SehOpening) -> bool;
+
+    /// Create a prefix consistency proof between two digests
+    fn consis_prove(
+        &self,
+        params: &SehParams,
+        digest1: &SehDigest,
+        digest2: &SehDigest,
+        prefix_len: usize,
+    ) -> SehProof;
+
+    /// Verify a prefix consistency proof
+    fn consis_verify(
+        &self,
+        params: &SehParams,
+        digest1: &SehDigest,
+        digest2: &SehDigest,
+        proof: &SehProof,
+    ) -> bool;
+}
+
+/// Stub SEH implementation using simple Merkle tree
+///
+/// WARNING: This is a simplified implementation for development.
+/// A production version would use FHE ciphertexts at leaves.
+#[derive(Clone, Debug)]
+pub struct StubSeh {
+    fhe: StubFhe,
+}
+
+impl Default for StubSeh {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StubSeh {
+    pub fn new() -> Self {
+        Self { fhe: StubFhe }
+    }
+
+    #[allow(dead_code)]
+    fn compute_tree_height(num_elements: usize) -> usize {
+        if num_elements <= 1 {
+            return 0;
+        }
+        let mut height = 0;
+        let mut size = 1;
+        while size < num_elements {
+            size *= 2;
+            height += 1;
+        }
+        height
+    }
+
+    fn hash_pair(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(left);
+        hasher.update(right);
+        hasher.finalize().into()
+    }
+
+    fn build_tree(&self, leaves: &[[u8; 32]]) -> Vec<Vec<[u8; 32]>> {
+        let mut layers = vec![leaves.to_vec()];
+
+        while layers.last().map(|l| l.len()).unwrap_or(0) > 1 {
+            let prev_layer = layers.last().unwrap();
+            let mut new_layer = Vec::new();
+
+            for chunk in prev_layer.chunks(2) {
+                let left = chunk[0];
+                let right = if chunk.len() > 1 {
+                    chunk[1]
+                } else {
+                    [0u8; 32]
+                };
+                new_layer.push(Self::hash_pair(&left, &right));
+            }
+
+            layers.push(new_layer);
+        }
+
+        layers
+    }
+}
+
+impl SehScheme for StubSeh {
+    type Fhe = StubFhe;
+
+    fn gen(&self, params: &SehParams) -> SehParams {
+        params.clone()
+    }
+
+    fn hash(&self, params: &SehParams, values: &[bool]) -> (SehDigest, Vec<FheCiphertext>) {
+        let (_, pk) = self.fhe.keygen(&params.fhe_params);
+
+        let ciphertexts: Vec<FheCiphertext> = values
+            .iter()
+            .map(|&v| self.fhe.encrypt_bit(&pk, v))
+            .collect();
+
+        let leaf_hashes: Vec<[u8; 32]> = ciphertexts
+            .iter()
+            .map(|ct| {
+                let mut hasher = Sha256::new();
+                hasher.update(&ct.data);
+                hasher.finalize().into()
+            })
+            .collect();
+
+        let padded_len = leaf_hashes.len().next_power_of_two();
+        let mut padded_leaves = leaf_hashes;
+        padded_leaves.resize(padded_len, [0u8; 32]);
+
+        let tree = self.build_tree(&padded_leaves);
+        let root = tree.last().and_then(|l| l.first()).copied().unwrap_or([0u8; 32]);
+        let height = tree.len().saturating_sub(1);
+
+        (SehDigest { root, height }, ciphertexts)
+    }
+
+    fn open(
+        &self,
+        params: &SehParams,
+        _values: &[bool],
+        ciphertexts: &[FheCiphertext],
+        position: usize,
+    ) -> SehOpening {
+        let leaf_hashes: Vec<[u8; 32]> = ciphertexts
+            .iter()
+            .map(|ct| {
+                let mut hasher = Sha256::new();
+                hasher.update(&ct.data);
+                hasher.finalize().into()
+            })
+            .collect();
+
+        let padded_len = leaf_hashes.len().next_power_of_two();
+        let mut padded_leaves = leaf_hashes;
+        padded_leaves.resize(padded_len, [0u8; 32]);
+
+        let tree = self.build_tree(&padded_leaves);
+
+        let mut sibling_hashes = Vec::new();
+        let mut idx = position;
+
+        for layer in &tree[..tree.len().saturating_sub(1)] {
+            let sibling_idx = if idx % 2 == 0 { idx + 1 } else { idx - 1 };
+            let sibling = layer.get(sibling_idx).copied().unwrap_or([0u8; 32]);
+            sibling_hashes.push(sibling);
+            idx /= 2;
+        }
+
+        let leaf_ct = ciphertexts.get(position).cloned().unwrap_or_else(|| {
+            let (_, pk) = self.fhe.keygen(&params.fhe_params);
+            self.fhe.encrypt_bit(&pk, false)
+        });
+
+        SehOpening {
+            position,
+            leaf_ciphertext: leaf_ct,
+            sibling_hashes,
+        }
+    }
+
+    fn verify(&self, _params: &SehParams, digest: &SehDigest, opening: &SehOpening) -> bool {
+        let mut hasher = Sha256::new();
+        hasher.update(&opening.leaf_ciphertext.data);
+        let mut current: [u8; 32] = hasher.finalize().into();
+
+        let mut idx = opening.position;
+
+        for sibling in &opening.sibling_hashes {
+            current = if idx % 2 == 0 {
+                Self::hash_pair(&current, sibling)
+            } else {
+                Self::hash_pair(sibling, &current)
+            };
+            idx /= 2;
+        }
+
+        current == digest.root
+    }
+
+    fn consis_prove(
+        &self,
+        _params: &SehParams,
+        digest1: &SehDigest,
+        digest2: &SehDigest,
+        prefix_len: usize,
+    ) -> SehProof {
+        SehProof {
+            common_nodes: vec![digest1.root, digest2.root],
+            diverge_depth: prefix_len,
+        }
+    }
+
+    fn consis_verify(
+        &self,
+        _params: &SehParams,
+        digest1: &SehDigest,
+        digest2: &SehDigest,
+        proof: &SehProof,
+    ) -> bool {
+        proof.common_nodes.len() == 2
+            && proof.common_nodes[0] == digest1.root
+            && proof.common_nodes[1] == digest2.root
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_seh_hash_deterministic() {
+        let seh = StubSeh::new();
+        let params = SehParams::default();
+        let values = vec![true, false, true, false];
+
+        let (digest1, _) = seh.hash(&params, &values);
+        let (digest2, _) = seh.hash(&params, &values);
+
+        assert_eq!(digest1.root, digest2.root);
+    }
+
+    #[test]
+    fn test_seh_open_verify() {
+        let seh = StubSeh::new();
+        let params = SehParams::default();
+        let values = vec![true, false, true, false];
+
+        let (digest, ciphertexts) = seh.hash(&params, &values);
+
+        for pos in 0..values.len() {
+            let opening = seh.open(&params, &values, &ciphertexts, pos);
+            assert!(seh.verify(&params, &digest, &opening));
+        }
+    }
+
+    #[test]
+    fn test_seh_invalid_opening() {
+        let seh = StubSeh::new();
+        let params = SehParams::default();
+        let values = vec![true, false, true, false];
+
+        let (digest, ciphertexts) = seh.hash(&params, &values);
+        let mut opening = seh.open(&params, &values, &ciphertexts, 0);
+
+        opening.sibling_hashes[0] = [1u8; 32];
+
+        assert!(!seh.verify(&params, &digest, &opening));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,25 @@
 //! - `crypto`: Cryptographic primitives (FHE, SEH, PRF, PRG, small-iO)
 //! - `lio`: Local iO implementation
 //! - `padding`: Circuit padding to fixed topology
+//!
+//! ## Implementation Status (Milestone 3)
+//!
+//! | Component | Status | Notes |
+//! |-----------|--------|-------|
+//! | GGM PRF | Real | Standard textbook construction over SHA-256 PRG |
+//! | SHA-256 PRG | Real | H(seed ∥ ctr) expansion, RO model |
+//! | Wire labels | Real | Two random 32-byte labels per wire (L_i^0, L_i^1) |
+//! | Wire encryption | Real | PRF-masked output labels keyed by input labels |
+//! | MAC tags | Real | Generated AND verified during evaluation |
+//! | FHE | Feature-gated | StubFhe (default) or TfheFhe (tfhe-backend feature) |
+//! | SEH | Real | verify_seh(), evaluate_with_seh_check(), consistency proofs |
+//! | SmallObf | Structural | Per-gate obfuscated gadget (stub iO, explicit assumption) |
+//! | PRF puncturing | Real | prf_input_for_entry() exposes exact security mapping |
+//!
+//! ## Cargo Features
+//!
+//! - `stub-fhe` (default): Fast stub FHE for development/testing
+//! - `tfhe-backend`: Real LWE-based FHE using the tfhe crate (slow to compile)
 
 pub mod circuit;
 pub mod crypto;
@@ -67,7 +86,7 @@ pub mod padding;
 
 pub use circuit::{Circuit, ControlFunction, EquivalenceProof, Gate};
 pub use crypto::{FheScheme, PuncturablePrf, Prg, SehScheme, SmallObf};
-pub use lio::{LiO, LiOError, LiOParams, ObfuscatedLiO};
+pub use lio::{LiO, LiOError, LiOParams, ObfuscatedLiO, WireLabels};
 pub use padding::{pad, pad_optimized, pad_single, PaddedCircuit, PaddingOverhead};
 
 use circuit::to_ef_proof;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,252 +52,53 @@
 //!    - Gate-by-gate obfuscation
 //!    - SEH for consistency proofs
 //!    - Puncturable PRFs + MACs for wire encryption
+//!
+//! ## Module Structure
+//!
+//! - `circuit`: Circuit representation (gates, wires, evaluation)
+//! - `crypto`: Cryptographic primitives (FHE, SEH, PRF, PRG, small-iO)
+//! - `lio`: Local iO implementation
+//! - `padding`: Circuit padding to fixed topology
 
-// ============================================================================
-// Stub Types (placeholders for dependencies from circuit-mixing-research)
-// ============================================================================
+pub mod circuit;
+pub mod crypto;
+pub mod lio;
+pub mod padding;
 
-pub mod stub {
-    use rand::Rng;
+pub use circuit::{Circuit, ControlFunction, EquivalenceProof, Gate};
+pub use crypto::{FheScheme, PuncturablePrf, Prg, SehScheme, SmallObf};
+pub use lio::{LiO, LiOError, LiOParams, ObfuscatedLiO};
+pub use padding::{pad, pad_optimized, pad_single, PaddedCircuit, PaddingOverhead};
 
-    #[derive(Clone, Debug, Copy, PartialEq, Eq)]
-    pub enum ControlFunction {
-        F,
-        And,
-        Xor,
-        Or,
-        Nand,
-        Nor,
-        Xnor,
-        AndNot,
-    }
-
-    impl ControlFunction {
-        pub fn evaluate(&self, a: bool, b: bool) -> bool {
-            match self {
-                Self::F => false,
-                Self::And => a && b,
-                Self::Xor => a ^ b,
-                Self::Or => a || b,
-                Self::Nand => !(a && b),
-                Self::Nor => !(a || b),
-                Self::Xnor => !(a ^ b),
-                Self::AndNot => a && !b,
-            }
-        }
-    }
-
-    #[derive(Clone, Debug)]
-    pub struct Gate {
-        pub output_wire: u8,
-        pub input_wire_a: u8,
-        pub input_wire_b: u8,
-        pub control_function: ControlFunction,
-    }
-
-    impl Gate {
-        pub fn new(output: u8, a: u8, b: u8, func: ControlFunction) -> Self {
-            Self {
-                output_wire: output,
-                input_wire_a: a,
-                input_wire_b: b,
-                control_function: func,
-            }
-        }
-    }
-
-    #[derive(Clone, Debug)]
-    pub struct Circuit {
-        pub gates: Vec<Gate>,
-        pub num_wires: usize,
-    }
-
-    impl Circuit {
-        pub fn new(gates: Vec<Gate>, num_wires: usize) -> Self {
-            Self { gates, num_wires }
-        }
-
-        pub fn evaluate(&self, input: usize) -> usize {
-            let mut wires = vec![false; self.num_wires];
-            for i in 0..self.num_wires {
-                wires[i] = (input >> i) & 1 == 1;
-            }
-            for gate in &self.gates {
-                let a = wires[gate.input_wire_a as usize];
-                let b = wires[gate.input_wire_b as usize];
-                wires[gate.output_wire as usize] = gate.control_function.evaluate(a, b);
-            }
-            let mut output = 0usize;
-            for (i, &w) in wires.iter().enumerate() {
-                if w {
-                    output |= 1 << i;
-                }
-            }
-            output
-        }
-
-        pub fn random_r57(num_wires: usize, num_gates: usize) -> Self {
-            let mut rng = rand::thread_rng();
-            let funcs = [
-                ControlFunction::And,
-                ControlFunction::Xor,
-                ControlFunction::Or,
-                ControlFunction::Nand,
-            ];
-            let gates: Vec<Gate> = (0..num_gates)
-                .map(|_| {
-                    let out = rng.gen_range(0..num_wires) as u8;
-                    let a = rng.gen_range(0..num_wires) as u8;
-                    let b = rng.gen_range(0..num_wires) as u8;
-                    let func = funcs[rng.gen_range(0..funcs.len())];
-                    Gate::new(out, a, b, func)
-                })
-                .collect();
-            Self { gates, num_wires }
-        }
-    }
-
-    #[derive(Clone, Debug)]
-    pub struct EquivalenceProof {
-        pub circuit_a_hash: [u8; 32],
-        pub circuit_b_hash: [u8; 32],
-        pub proof_steps: Vec<String>,
-    }
-
-    impl EquivalenceProof {
-        pub fn dummy(circuit: &Circuit) -> Self {
-            use sha2::{Sha256, Digest};
-            let mut hasher = Sha256::new();
-            hasher.update(format!("{:?}", circuit.gates));
-            let hash: [u8; 32] = hasher.finalize().into();
-            Self {
-                circuit_a_hash: hash,
-                circuit_b_hash: hash,
-                proof_steps: vec!["identity".to_string()],
-            }
-        }
-    }
-
-    #[derive(Clone, Debug)]
-    pub struct EFProof {
-        pub proof_size: usize,
-    }
-
-    pub fn to_ef_proof(proof: &EquivalenceProof) -> EFProof {
-        EFProof {
-            proof_size: proof.proof_steps.len() * 64 + 128,
-        }
-    }
-
-    #[derive(Clone, Debug)]
-    pub struct BaseIOParams {
-        pub lambda: usize,
-    }
-
-    impl BaseIOParams {
-        pub fn for_augmented_gate(lambda: usize) -> Self {
-            Self { lambda }
-        }
-    }
-
-    #[derive(Clone, Debug)]
-    pub struct LiOParams {
-        pub lambda: usize,
-        pub subcircuit_size: usize,
-        pub base_io_params: BaseIOParams,
-    }
-
-    impl LiOParams {
-        pub fn new(lambda: usize, subcircuit_size: usize) -> Self {
-            Self {
-                lambda,
-                subcircuit_size,
-                base_io_params: BaseIOParams::for_augmented_gate(lambda),
-            }
-        }
-    }
-
-    #[derive(Clone, Debug)]
-    pub struct ObfuscatedLiO {
-        pub base_io_size_bytes: usize,
-        pub wire_keys: Vec<[u8; 32]>,
-    }
-
-    #[derive(Clone, Debug)]
-    pub enum LiOError {
-        InvalidCircuit(String),
-    }
-
-    impl std::fmt::Display for LiOError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            match self {
-                Self::InvalidCircuit(s) => write!(f, "Invalid circuit: {}", s),
-            }
-        }
-    }
-
-    impl std::error::Error for LiOError {}
-
-    pub struct LiO {
-        pub params: LiOParams,
-    }
-
-    impl LiO {
-        pub fn new(params: LiOParams) -> Self {
-            Self { params }
-        }
-
-        pub fn obfuscate(&self, circuit: &Circuit) -> Result<ObfuscatedLiO, LiOError> {
-            let base_io_size_bytes = circuit.gates.len() * 500;
-            let wire_keys = vec![[0u8; 32]; circuit.num_wires];
-            Ok(ObfuscatedLiO {
-                base_io_size_bytes,
-                wire_keys,
-            })
-        }
-    }
-
-    #[derive(Clone, Debug)]
-    pub struct MixResult {
-        pub circuit: Circuit,
-        pub proof: EquivalenceProof,
-    }
-
-    pub fn proven_stealth_mix(circuit: &Circuit) -> MixResult {
-        MixResult {
-            circuit: circuit.clone(),
-            proof: EquivalenceProof::dummy(circuit),
-        }
-    }
-
-    pub fn proven_identity_injection(circuit: &Circuit, _rounds: usize) -> MixResult {
-        proven_stealth_mix(circuit)
-    }
-}
-
-use stub::*;
+use circuit::to_ef_proof;
 
 // ============================================================================
 // Parameters
 // ============================================================================
 
+/// Parameters for Ma-Dai-Shi quasi-linear iO
 #[derive(Clone, Debug)]
 pub struct MaDaiShiParams {
+    /// Security parameter (bits)
     pub lambda: usize,
+    /// Maximum circuit size (number of gates)
     pub max_circuit_size: usize,
+    /// Maximum proof size (bytes)
     pub max_proof_size: usize,
+    /// Subcircuit size for LiO (s = O(log N))
     pub subcircuit_size: usize,
+    /// LiO parameters
     pub lio_params: LiOParams,
 }
 
 impl MaDaiShiParams {
+    /// Create new parameters with explicit values
     pub fn new(lambda: usize, max_circuit_size: usize, max_proof_size: usize) -> Self {
         let total = max_circuit_size + max_proof_size;
         let subcircuit_size = ((total as f64).log2().ceil() as usize).max(4);
-        
-        let mut lio_params = LiOParams::new(lambda, subcircuit_size);
-        lio_params.base_io_params = BaseIOParams::for_augmented_gate(lambda);
-        
+
+        let lio_params = LiOParams::new(lambda, subcircuit_size);
+
         Self {
             lambda,
             max_circuit_size,
@@ -306,25 +107,31 @@ impl MaDaiShiParams {
             lio_params,
         }
     }
-    
+
+    /// Create parameters based on a specific circuit and proof
     pub fn for_circuit_and_proof(circuit: &Circuit, proof: &EquivalenceProof) -> Self {
         let n_circ = circuit.gates.len();
         let ef_proof = to_ef_proof(proof);
         let n_proof = ef_proof.proof_size;
         Self::new(128, n_circ, n_proof)
     }
-    
+
+    /// Conservative parameters (larger sizes, higher security)
     pub fn conservative(circuit_size: usize, proof_size: usize) -> Self {
-        Self::new(256, circuit_size.next_power_of_two(), proof_size.next_power_of_two())
+        Self::new(
+            256,
+            circuit_size.next_power_of_two(),
+            proof_size.next_power_of_two(),
+        )
     }
-    
+
+    /// Optimized parameters (smaller overhead)
     pub fn optimized(circuit_size: usize, proof_size: usize) -> Self {
         let total = circuit_size + proof_size;
         let subcircuit_size = ((total as f64).log2().ceil() as usize).max(2);
-        
-        let mut lio_params = LiOParams::new(100, subcircuit_size);
-        lio_params.base_io_params = BaseIOParams::for_augmented_gate(100);
-        
+
+        let lio_params = LiOParams::new(100, subcircuit_size);
+
         Self {
             lambda: 100,
             max_circuit_size: circuit_size,
@@ -333,14 +140,14 @@ impl MaDaiShiParams {
             lio_params,
         }
     }
-    
+
+    /// Aggressive parameters (minimal overhead, lower security margin)
     pub fn aggressive(circuit_size: usize, proof_size: usize) -> Self {
         let total = circuit_size + proof_size;
         let subcircuit_size = ((total as f64).log2().ceil() as usize).max(2);
-        
-        let mut lio_params = LiOParams::new(80, subcircuit_size);
-        lio_params.base_io_params = BaseIOParams::for_augmented_gate(80);
-        
+
+        let lio_params = LiOParams::new(80, subcircuit_size);
+
         Self {
             lambda: 80,
             max_circuit_size: circuit_size,
@@ -358,237 +165,39 @@ impl Default for MaDaiShiParams {
 }
 
 // ============================================================================
-// Padding Construction (Section 3.2)
-// ============================================================================
-
-#[derive(Clone, Debug)]
-pub struct PaddedCircuit {
-    pub main_circuit: Circuit,
-    pub filler_circuit: Circuit,
-    pub proof_circuit: Circuit,
-    pub and_tree: Vec<Gate>,
-    pub combined: Circuit,
-    pub original_size: usize,
-    pub overhead: PaddingOverhead,
-}
-
-#[derive(Clone, Debug)]
-pub struct PaddingOverhead {
-    pub original_gates: usize,
-    pub padded_gates: usize,
-    pub routing_gates: usize,
-    pub and_tree_gates: usize,
-    pub size_ratio: f64,
-}
-
-pub fn pad_single(circuit: &Circuit, n_bound: usize) -> Circuit {
-    if circuit.gates.is_empty() {
-        return create_identity_circuit(circuit.num_wires, n_bound);
-    }
-    
-    let mut padded_gates = Vec::new();
-    let num_wires = circuit.num_wires.max(4);
-    
-    padded_gates.extend(circuit.gates.iter().cloned());
-    
-    let routing_depth = ((n_bound as f64).log2().ceil() as usize).max(1);
-    let routing_gates = create_routing_network(num_wires, routing_depth, padded_gates.len());
-    padded_gates.extend(routing_gates);
-    
-    let copy_gates = create_copy_gadgets(num_wires, routing_depth);
-    padded_gates.extend(copy_gates);
-    
-    while padded_gates.len() < n_bound {
-        let wire = (padded_gates.len() % num_wires) as u8;
-        let c1 = ((padded_gates.len() + 1) % num_wires) as u8;
-        let c2 = ((padded_gates.len() + 2) % num_wires) as u8;
-        
-        padded_gates.push(Gate::new(wire, c1, c2, ControlFunction::Xor));
-        if padded_gates.len() < n_bound {
-            padded_gates.push(Gate::new(wire, c1, c2, ControlFunction::Xor));
-        }
-    }
-    
-    padded_gates.truncate(n_bound);
-    
-    Circuit {
-        gates: padded_gates,
-        num_wires,
-    }
-}
-
-fn create_routing_network(num_wires: usize, depth: usize, start_idx: usize) -> Vec<Gate> {
-    let mut gates = Vec::new();
-    
-    for level in 0..depth {
-        let stride = 1 << level;
-        for i in 0..(num_wires / (2 * stride)).max(1) {
-            let a = ((i * 2 * stride) % num_wires) as u8;
-            let b = (((i * 2 + 1) * stride) % num_wires) as u8;
-            let out = ((i * stride + start_idx + level) % num_wires) as u8;
-            
-            gates.push(Gate::new(out, a, b, ControlFunction::Xor));
-        }
-    }
-    
-    gates
-}
-
-fn create_copy_gadgets(num_wires: usize, depth: usize) -> Vec<Gate> {
-    let mut gates = Vec::new();
-    
-    for level in 0..depth {
-        for i in 0..num_wires.min(4) {
-            let src = i as u8;
-            let dst = ((i + level + 1) % num_wires) as u8;
-            let ctrl = ((i + level + 2) % num_wires) as u8;
-            
-            gates.push(Gate::new(dst, src, ctrl, ControlFunction::Xor));
-        }
-    }
-    
-    gates
-}
-
-fn create_identity_circuit(num_wires: usize, size: usize) -> Circuit {
-    let mut gates = Vec::with_capacity(size);
-    let num_wires = num_wires.max(4);
-    
-    for i in 0..(size / 2) {
-        let wire = (i % num_wires) as u8;
-        let c1 = ((i + 1) % num_wires) as u8;
-        let c2 = ((i + 2) % num_wires) as u8;
-        
-        gates.push(Gate::new(wire, c1, c2, ControlFunction::Xor));
-        gates.push(Gate::new(wire, c1, c2, ControlFunction::Xor));
-    }
-    
-    if size % 2 == 1 {
-        let wire = ((size / 2) % num_wires) as u8;
-        gates.push(Gate::new(wire, wire, wire, ControlFunction::F));
-    }
-    
-    Circuit { gates, num_wires }
-}
-
-fn create_and_tree(num_outputs: usize, num_wires: usize) -> Vec<Gate> {
-    let mut gates = Vec::new();
-    
-    if num_outputs <= 1 {
-        return gates;
-    }
-    
-    let depth = ((num_outputs as f64).log2().ceil() as usize).max(1);
-    
-    for level in 0..depth {
-        let pairs = (num_outputs >> level).max(1) / 2;
-        for i in 0..pairs {
-            let a = (i * 2 % num_wires) as u8;
-            let b = ((i * 2 + 1) % num_wires) as u8;
-            let out = ((num_wires - 1 - level - i) % num_wires) as u8;
-            
-            gates.push(Gate::new(out, a, b, ControlFunction::And));
-        }
-    }
-    
-    gates
-}
-
-pub fn pad(circuit: &Circuit, n_circ: usize, n_proof: usize) -> PaddedCircuit {
-    let num_wires = circuit.num_wires.max(8);
-    let original_size = circuit.gates.len();
-    
-    let main_circuit = pad_single(circuit, n_circ);
-    let filler_circuit = create_identity_circuit(num_wires, n_circ);
-    
-    let c = 2;
-    let proof_size = c * (n_circ + n_proof);
-    let proof_circuit = create_identity_circuit(num_wires, proof_size.min(n_circ * 4));
-    
-    let and_tree = create_and_tree(3, num_wires);
-    
-    let mut combined_gates = Vec::new();
-    combined_gates.extend(main_circuit.gates.iter().cloned());
-    combined_gates.extend(filler_circuit.gates.iter().cloned());
-    combined_gates.extend(proof_circuit.gates.iter().cloned());
-    combined_gates.extend(and_tree.iter().cloned());
-    
-    let padded_gates = combined_gates.len();
-    let routing_gates = main_circuit.gates.len().saturating_sub(original_size);
-    
-    let combined = Circuit {
-        gates: combined_gates,
-        num_wires,
-    };
-    
-    PaddedCircuit {
-        main_circuit,
-        filler_circuit,
-        proof_circuit,
-        and_tree: and_tree.clone(),
-        combined,
-        original_size,
-        overhead: PaddingOverhead {
-            original_gates: original_size,
-            padded_gates,
-            routing_gates,
-            and_tree_gates: and_tree.len(),
-            size_ratio: padded_gates as f64 / original_size.max(1) as f64,
-        },
-    }
-}
-
-pub fn pad_optimized(circuit: &Circuit) -> PaddedCircuit {
-    let num_wires = circuit.num_wires.max(4);
-    let original_size = circuit.gates.len();
-    
-    let target_size = original_size + ((original_size as f64).log2().ceil() as usize).max(4) * 2;
-    let main_circuit = pad_single(circuit, target_size);
-    
-    let filler_circuit = Circuit { gates: vec![], num_wires };
-    let proof_circuit = Circuit { gates: vec![], num_wires };
-    let and_tree = vec![];
-    
-    let padded_gates = main_circuit.gates.len();
-    let routing_gates = padded_gates.saturating_sub(original_size);
-    
-    PaddedCircuit {
-        main_circuit: main_circuit.clone(),
-        filler_circuit,
-        proof_circuit,
-        and_tree,
-        combined: main_circuit,
-        original_size,
-        overhead: PaddingOverhead {
-            original_gates: original_size,
-            padded_gates,
-            routing_gates,
-            and_tree_gates: 0,
-            size_ratio: padded_gates as f64 / original_size.max(1) as f64,
-        },
-    }
-}
-
-// ============================================================================
 // Main Quasi-Linear iO Construction
 // ============================================================================
 
+/// Result of Ma-Dai-Shi obfuscation
 pub struct MaDaiShiObfuscated {
+    /// The LiO-obfuscated program
     pub lio_obfuscated: ObfuscatedLiO,
+    /// Padding overhead information
     pub padding_info: PaddingOverhead,
+    /// Size of the EF proof used
     pub ef_proof_size: usize,
+    /// Obfuscation metrics
     pub metrics: ObfuscationMetrics,
 }
 
+/// Metrics for obfuscation quality and overhead
 #[derive(Clone, Debug)]
 pub struct ObfuscationMetrics {
+    /// Original circuit size (gates)
     pub original_size: usize,
+    /// Proof size (bytes)
     pub proof_size: usize,
+    /// Padded circuit size (gates)
     pub padded_size: usize,
+    /// Subcircuit size (s parameter)
     pub subcircuit_size: usize,
+    /// Number of hybrids in security proof
     pub num_hybrids: usize,
+    /// Total obfuscated program size (bytes)
     pub obfuscated_bytes: usize,
+    /// Size ratio (obfuscated / original)
     pub size_ratio: f64,
+    /// Whether the overhead is quasi-linear
     pub is_quasi_linear: bool,
 }
 
@@ -607,54 +216,59 @@ impl std::fmt::Display for ObfuscationMetrics {
     }
 }
 
+/// The main quasi-linear obfuscator
 pub struct QuasiLinearObfuscator {
     params: MaDaiShiParams,
     lio: LiO,
 }
 
 impl QuasiLinearObfuscator {
+    /// Create a new obfuscator with given parameters
     pub fn new(params: MaDaiShiParams) -> Self {
         let lio = LiO::new(params.lio_params.clone());
         Self { params, lio }
     }
-    
+
+    /// Create with default parameters
     pub fn with_default_params() -> Self {
         Self::new(MaDaiShiParams::default())
     }
-    
+
+    /// Create with parameters tailored for specific circuit and proof
     pub fn for_circuit_and_proof(circuit: &Circuit, proof: &EquivalenceProof) -> Self {
         let params = MaDaiShiParams::for_circuit_and_proof(circuit, proof);
         Self::new(params)
     }
-    
+
+    /// Obfuscate a circuit with an equivalence proof
     pub fn obfuscate(
         &self,
         circuit: &Circuit,
         proof: &EquivalenceProof,
     ) -> Result<MaDaiShiObfuscated, MaDaiShiError> {
         let ef_proof = to_ef_proof(proof);
-        
+
         let n_circ = self.params.max_circuit_size.max(circuit.gates.len());
         let n_proof = self.params.max_proof_size.max(ef_proof.proof_size);
-        
+
         let padded = pad(circuit, n_circ, n_proof);
-        
-        let lio_obfuscated = self.lio.obfuscate(&padded.combined)
+
+        let lio_obfuscated = self
+            .lio
+            .obfuscate(&padded.combined)
             .map_err(MaDaiShiError::LiOError)?;
-        
+
         let total = n_circ + n_proof;
         let log_total = ((total as f64).log2().ceil() as usize).max(1);
         let num_hybrids = total * log_total;
-        
-        let obfuscated_bytes = lio_obfuscated.base_io_size_bytes
-            + lio_obfuscated.wire_keys.len() * 64
-            + 256;
-        
+
+        let obfuscated_bytes = lio_obfuscated.size_bytes();
+
         let size_ratio = obfuscated_bytes as f64 / (circuit.gates.len() * 4).max(1) as f64;
-        
+
         let polylog_bound = (circuit.gates.len() as f64) * (log_total as f64).powi(3) * 200.0;
         let is_quasi_linear = (obfuscated_bytes as f64) < polylog_bound;
-        
+
         let metrics = ObfuscationMetrics {
             original_size: circuit.gates.len(),
             proof_size: ef_proof.proof_size,
@@ -665,7 +279,7 @@ impl QuasiLinearObfuscator {
             size_ratio,
             is_quasi_linear,
         };
-        
+
         Ok(MaDaiShiObfuscated {
             lio_obfuscated,
             padding_info: padded.overhead,
@@ -673,31 +287,37 @@ impl QuasiLinearObfuscator {
             metrics,
         })
     }
-    
+
+    /// Obfuscate with automatic proof generation (for equivalent circuits)
     pub fn obfuscate_with_mixing(
         &self,
         circuit: &Circuit,
     ) -> Result<MaDaiShiObfuscated, MaDaiShiError> {
-        let mix_result = proven_stealth_mix(circuit);
-        self.obfuscate(&mix_result.circuit, &mix_result.proof)
+        let proof = EquivalenceProof::dummy(circuit);
+        self.obfuscate(circuit, &proof)
     }
-    
-    pub fn estimate_overhead(&self, circuit: &Circuit, proof: &EquivalenceProof) -> ObfuscationMetrics {
+
+    /// Estimate overhead without performing full obfuscation
+    pub fn estimate_overhead(
+        &self,
+        circuit: &Circuit,
+        proof: &EquivalenceProof,
+    ) -> ObfuscationMetrics {
         let ef_proof = to_ef_proof(proof);
         let n_circ = circuit.gates.len();
         let n_proof = ef_proof.proof_size;
         let total = n_circ + n_proof;
         let log_total = ((total as f64).log2().ceil() as usize).max(1);
-        
+
         let padded_size = n_circ + log_total * 4 + n_proof / 8;
         let per_gate_bytes = 500;
         let lio_overhead = padded_size * per_gate_bytes * log_total / 4;
-        
+
         let size_ratio = lio_overhead as f64 / (n_circ * 4).max(1) as f64;
-        
+
         let polylog_bound = (n_circ as f64) * (log_total as f64).powi(3) * 200.0;
         let is_quasi_linear = (lio_overhead as f64) < polylog_bound;
-        
+
         ObfuscationMetrics {
             original_size: n_circ,
             proof_size: n_proof,
@@ -711,11 +331,16 @@ impl QuasiLinearObfuscator {
     }
 }
 
+/// Errors that can occur during obfuscation
 #[derive(Debug, Clone)]
 pub enum MaDaiShiError {
+    /// Error in LiO obfuscation
     LiOError(LiOError),
+    /// Invalid equivalence proof
     InvalidProof(String),
+    /// Circuit exceeds maximum size
     CircuitTooLarge { size: usize, max: usize },
+    /// Proof exceeds maximum size
     ProofTooLarge { size: usize, max: usize },
 }
 
@@ -724,10 +349,12 @@ impl std::fmt::Display for MaDaiShiError {
         match self {
             Self::LiOError(e) => write!(f, "LiO error: {}", e),
             Self::InvalidProof(s) => write!(f, "Invalid proof: {}", s),
-            Self::CircuitTooLarge { size, max } => 
-                write!(f, "Circuit too large: {} gates (max {})", size, max),
-            Self::ProofTooLarge { size, max } =>
-                write!(f, "Proof too large: {} symbols (max {})", size, max),
+            Self::CircuitTooLarge { size, max } => {
+                write!(f, "Circuit too large: {} gates (max {})", size, max)
+            }
+            Self::ProofTooLarge { size, max } => {
+                write!(f, "Proof too large: {} symbols (max {})", size, max)
+            }
         }
     }
 }
@@ -735,106 +362,10 @@ impl std::fmt::Display for MaDaiShiError {
 impl std::error::Error for MaDaiShiError {}
 
 // ============================================================================
-// Hybrid Sequence (for s-equivalence proof)
-// ============================================================================
-
-#[derive(Clone, Debug)]
-pub struct HybridCircuit {
-    pub index: usize,
-    pub circuit: Circuit,
-    pub change_description: String,
-    pub diff_size: usize,
-}
-
-pub fn generate_hybrid_sequence(
-    padded1: &PaddedCircuit,
-    padded2: &PaddedCircuit,
-    s: usize,
-) -> Vec<HybridCircuit> {
-    let mut hybrids = Vec::new();
-    
-    hybrids.push(HybridCircuit {
-        index: 0,
-        circuit: padded1.combined.clone(),
-        change_description: "Initial: Pad(C1)".to_string(),
-        diff_size: 0,
-    });
-    
-    let step_size = s.max(1);
-    
-    let mut current = padded1.combined.clone();
-    let mut idx = 1;
-    
-    for i in (0..padded1.filler_circuit.gates.len()).step_by(step_size) {
-        let end = (i + step_size).min(padded1.filler_circuit.gates.len());
-        hybrids.push(HybridCircuit {
-            index: idx,
-            circuit: current.clone(),
-            change_description: format!("Grow C2: gates [{}, {})", i, end),
-            diff_size: end - i,
-        });
-        idx += 1;
-    }
-    
-    for i in (0..padded1.proof_circuit.gates.len()).step_by(step_size) {
-        let end = (i + step_size).min(padded1.proof_circuit.gates.len());
-        hybrids.push(HybridCircuit {
-            index: idx,
-            circuit: current.clone(),
-            change_description: format!("Grow proof: gates [{}, {})", i, end),
-            diff_size: end - i,
-        });
-        idx += 1;
-    }
-    
-    for i in (0..padded1.main_circuit.gates.len()).step_by(step_size) {
-        let end = (i + step_size).min(padded1.main_circuit.gates.len());
-        
-        if i < padded2.main_circuit.gates.len() {
-            let replace_end = end.min(padded2.main_circuit.gates.len());
-            for j in i..replace_end {
-                if j < current.gates.len() {
-                    current.gates[j] = padded2.main_circuit.gates[j].clone();
-                }
-            }
-        }
-        
-        hybrids.push(HybridCircuit {
-            index: idx,
-            circuit: current.clone(),
-            change_description: format!("Replace C1->C2: gates [{}, {})", i, end),
-            diff_size: end - i,
-        });
-        idx += 1;
-    }
-    
-    hybrids.push(HybridCircuit {
-        index: idx,
-        circuit: padded2.combined.clone(),
-        change_description: "Final: Pad(C2)".to_string(),
-        diff_size: 0,
-    });
-    
-    hybrids
-}
-
-pub fn verify_hybrid_sequence(hybrids: &[HybridCircuit], s: usize) -> bool {
-    for i in 0..hybrids.len().saturating_sub(1) {
-        if hybrids[i].diff_size > s && hybrids[i].diff_size > 0 {
-            eprintln!(
-                "[WARN] Hybrid {} -> {} has diff_size {} > s={}",
-                i, i + 1, hybrids[i].diff_size, s
-            );
-            return false;
-        }
-    }
-    true
-}
-
-// ============================================================================
 // Convenience Functions
 // ============================================================================
 
+/// Obfuscate a circuit with the given equivalence proof
 pub fn obfuscate(
     circuit: &Circuit,
     proof: &EquivalenceProof,
@@ -843,35 +374,34 @@ pub fn obfuscate(
     obfuscator.obfuscate(circuit, proof)
 }
 
+/// Obfuscate with automatic proof generation
 pub fn obfuscate_auto(circuit: &Circuit) -> Result<MaDaiShiObfuscated, MaDaiShiError> {
     let obfuscator = QuasiLinearObfuscator::with_default_params();
     obfuscator.obfuscate_with_mixing(circuit)
 }
 
+/// Obfuscate with optimized parameters
 pub fn obfuscate_optimized(circuit: &Circuit) -> Result<MaDaiShiObfuscated, MaDaiShiError> {
-    let mix_result = proven_stealth_mix(circuit);
-    let ef_proof = to_ef_proof(&mix_result.proof);
-    
-    let padded = pad_optimized(&mix_result.circuit);
-    
+    let proof = EquivalenceProof::dummy(circuit);
+    let ef_proof = to_ef_proof(&proof);
+
+    let padded = pad_optimized(circuit);
+
     let params = MaDaiShiParams::optimized(circuit.gates.len(), ef_proof.proof_size);
     let lio = LiO::new(params.lio_params.clone());
-    
-    let lio_obfuscated = lio.obfuscate(&padded.combined)
-        .map_err(MaDaiShiError::LiOError)?;
-    
+
+    let lio_obfuscated = lio.obfuscate(&padded.combined).map_err(MaDaiShiError::LiOError)?;
+
     let n_circ = circuit.gates.len();
     let n_proof = ef_proof.proof_size;
     let total = n_circ + n_proof;
     let log_total = ((total as f64).log2().ceil() as usize).max(1);
-    
-    let obfuscated_bytes = lio_obfuscated.base_io_size_bytes
-        + lio_obfuscated.wire_keys.len() * 64
-        + 256;
-    
+
+    let obfuscated_bytes = lio_obfuscated.size_bytes();
+
     let size_ratio = obfuscated_bytes as f64 / (n_circ * 4).max(1) as f64;
     let polylog_bound = (n_circ as f64) * (log_total as f64).powi(3) * 200.0;
-    
+
     let metrics = ObfuscationMetrics {
         original_size: n_circ,
         proof_size: n_proof,
@@ -882,7 +412,7 @@ pub fn obfuscate_optimized(circuit: &Circuit) -> Result<MaDaiShiObfuscated, MaDa
         size_ratio,
         is_quasi_linear: (obfuscated_bytes as f64) < polylog_bound,
     };
-    
+
     Ok(MaDaiShiObfuscated {
         lio_obfuscated,
         padding_info: padded.overhead,
@@ -891,25 +421,27 @@ pub fn obfuscate_optimized(circuit: &Circuit) -> Result<MaDaiShiObfuscated, MaDa
     })
 }
 
+/// Estimate obfuscation overhead without performing the full operation
 pub fn estimate_overhead(circuit: &Circuit, proof: &EquivalenceProof) -> ObfuscationMetrics {
     let obfuscator = QuasiLinearObfuscator::for_circuit_and_proof(circuit, proof);
     obfuscator.estimate_overhead(circuit, proof)
 }
 
+/// Estimate overhead with optimized parameters
 pub fn estimate_overhead_optimized(circuit: &Circuit, proof: &EquivalenceProof) -> ObfuscationMetrics {
     let ef_proof = to_ef_proof(proof);
     let n_circ = circuit.gates.len();
     let n_proof = ef_proof.proof_size;
     let total = n_circ + n_proof;
     let log_total = ((total as f64).log2().ceil() as usize).max(1);
-    
+
     let padded_size = n_circ + log_total * 2 + 8;
     let per_gate_bytes = 400;
     let lio_overhead = padded_size * per_gate_bytes;
-    
+
     let size_ratio = lio_overhead as f64 / (n_circ * 4).max(1) as f64;
     let polylog_bound = (n_circ as f64) * (log_total as f64).powi(3) * 200.0;
-    
+
     ObfuscationMetrics {
         original_size: n_circ,
         proof_size: n_proof,
@@ -923,41 +455,195 @@ pub fn estimate_overhead_optimized(circuit: &Circuit, proof: &EquivalenceProof) 
 }
 
 // ============================================================================
-// Re-exports for convenience
+// Compatibility module for proven mixing
 // ============================================================================
 
-pub use stub::{Circuit, Gate, ControlFunction, EquivalenceProof};
+/// Compatibility module with functions from the original stub implementation
+pub mod compat {
+    use crate::circuit::{Circuit, EquivalenceProof};
+
+    /// Result of proven circuit mixing
+    #[derive(Clone, Debug)]
+    pub struct MixResult {
+        /// The mixed circuit
+        pub circuit: Circuit,
+        /// Proof of equivalence
+        pub proof: EquivalenceProof,
+    }
+
+    /// Apply stealth mixing to a circuit (identity for now)
+    pub fn proven_stealth_mix(circuit: &Circuit) -> MixResult {
+        MixResult {
+            circuit: circuit.clone(),
+            proof: EquivalenceProof::dummy(circuit),
+        }
+    }
+
+    /// Apply identity injection mixing
+    pub fn proven_identity_injection(circuit: &Circuit, _rounds: usize) -> MixResult {
+        proven_stealth_mix(circuit)
+    }
+}
+
+// ============================================================================
+// Hybrid Sequence (for s-equivalence proof)
+// ============================================================================
+
+/// A hybrid circuit in the security reduction
+#[derive(Clone, Debug)]
+pub struct HybridCircuit {
+    /// Index in the hybrid sequence
+    pub index: usize,
+    /// The circuit at this hybrid step
+    pub circuit: Circuit,
+    /// Description of the change from previous hybrid
+    pub change_description: String,
+    /// Size of the difference from previous hybrid
+    pub diff_size: usize,
+}
+
+/// Generate the hybrid sequence between two padded circuits
+pub fn generate_hybrid_sequence(
+    padded1: &PaddedCircuit,
+    padded2: &PaddedCircuit,
+    s: usize,
+) -> Vec<HybridCircuit> {
+    let mut hybrids = Vec::new();
+
+    hybrids.push(HybridCircuit {
+        index: 0,
+        circuit: padded1.combined.clone(),
+        change_description: "Initial: Pad(C1)".to_string(),
+        diff_size: 0,
+    });
+
+    let step_size = s.max(1);
+
+    let mut current = padded1.combined.clone();
+    let mut idx = 1;
+
+    for i in (0..padded1.filler_circuit.gates.len()).step_by(step_size) {
+        let end = (i + step_size).min(padded1.filler_circuit.gates.len());
+        hybrids.push(HybridCircuit {
+            index: idx,
+            circuit: current.clone(),
+            change_description: format!("Grow C2: gates [{}, {})", i, end),
+            diff_size: end - i,
+        });
+        idx += 1;
+    }
+
+    for i in (0..padded1.proof_circuit.gates.len()).step_by(step_size) {
+        let end = (i + step_size).min(padded1.proof_circuit.gates.len());
+        hybrids.push(HybridCircuit {
+            index: idx,
+            circuit: current.clone(),
+            change_description: format!("Grow proof: gates [{}, {})", i, end),
+            diff_size: end - i,
+        });
+        idx += 1;
+    }
+
+    for i in (0..padded1.main_circuit.gates.len()).step_by(step_size) {
+        let end = (i + step_size).min(padded1.main_circuit.gates.len());
+
+        if i < padded2.main_circuit.gates.len() {
+            let replace_end = end.min(padded2.main_circuit.gates.len());
+            for j in i..replace_end {
+                if j < current.gates.len() {
+                    current.gates[j] = padded2.main_circuit.gates[j].clone();
+                }
+            }
+        }
+
+        hybrids.push(HybridCircuit {
+            index: idx,
+            circuit: current.clone(),
+            change_description: format!("Replace C1->C2: gates [{}, {})", i, end),
+            diff_size: end - i,
+        });
+        idx += 1;
+    }
+
+    hybrids.push(HybridCircuit {
+        index: idx,
+        circuit: padded2.combined.clone(),
+        change_description: "Final: Pad(C2)".to_string(),
+        diff_size: 0,
+    });
+
+    hybrids
+}
+
+/// Verify that a hybrid sequence respects the s-equivalence bound
+pub fn verify_hybrid_sequence(hybrids: &[HybridCircuit], s: usize) -> bool {
+    for i in 0..hybrids.len().saturating_sub(1) {
+        if hybrids[i].diff_size > s && hybrids[i].diff_size > 0 {
+            eprintln!(
+                "[WARN] Hybrid {} -> {} has diff_size {} > s={}",
+                i,
+                i + 1,
+                hybrids[i].diff_size,
+                s
+            );
+            return false;
+        }
+    }
+    true
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    
-    #[test]
-    fn test_pad_single() {
-        let circuit = Circuit::random_r57(8, 10);
-        let padded = pad_single(&circuit, 32);
-        
-        assert_eq!(padded.gates.len(), 32);
-        assert!(padded.num_wires >= circuit.num_wires);
-    }
-    
+
     #[test]
     fn test_ma_dai_shi_params() {
         let params = MaDaiShiParams::new(128, 100, 500);
-        
+
         assert_eq!(params.lambda, 128);
         assert!(params.subcircuit_size > 0);
         assert!(params.subcircuit_size < 20);
     }
-    
+
     #[test]
     fn test_obfuscate_auto() {
         let circuit = Circuit::random_r57(6, 10);
-        
+
         let result = obfuscate_auto(&circuit);
         assert!(result.is_ok());
-        
+
         let obf = result.unwrap();
         assert!(obf.metrics.is_quasi_linear);
+    }
+
+    #[test]
+    fn test_obfuscate_and_evaluate() {
+        let gates = vec![Gate::new(2, 0, 1, ControlFunction::And)];
+        let circuit = Circuit::new(gates, 3);
+
+        let result = obfuscate_auto(&circuit);
+        assert!(result.is_ok());
+
+        let obf = result.unwrap();
+        assert!(obf.metrics.padded_size > 0);
+        assert!(obf.metrics.original_size == 1);
+    }
+
+    #[test]
+    fn test_metrics_display() {
+        let metrics = ObfuscationMetrics {
+            original_size: 100,
+            proof_size: 500,
+            padded_size: 200,
+            subcircuit_size: 8,
+            num_hybrids: 4800,
+            obfuscated_bytes: 50000,
+            size_ratio: 125.0,
+            is_quasi_linear: true,
+        };
+
+        let display = format!("{}", metrics);
+        assert!(display.contains("100 gates"));
+        assert!(display.contains("[OK]"));
     }
 }

--- a/src/lio.rs
+++ b/src/lio.rs
@@ -1,0 +1,404 @@
+//! Local Indistinguishability Obfuscation (LiO)
+//!
+//! Implementation of the LiO construction from §5 of Ma-Dai-Shi 2025.
+//!
+//! LiO provides security for circuits that differ in only s = O(log N) gates.
+//! The full Ma-Dai-Shi iO is achieved by combining LiO with padding that
+//! ensures any two equivalent circuits become transitively s-equivalent.
+//!
+//! ## Construction Overview
+//!
+//! For each gate g in the circuit:
+//! 1. Generate wire encryption keys using puncturable PRF
+//! 2. Create encrypted truth table entries
+//! 3. Add MAC tags for verification
+//! 4. Wrap in small-circuit iO for the gate gadget
+//!
+//! ## Security
+//!
+//! LiO security relies on:
+//! - FHE (for SEH construction)
+//! - Puncturable PRF (for wire keys)
+//! - PRG (for mask generation)
+//! - Small-circuit iO (for gate gadgets)
+//!
+//! # WARNING: Current Implementation Status (Milestone 0/1)
+//!
+//! **This implementation is NOT cryptographically secure.** It provides:
+//!
+//! - [OK] Functional correctness: `ObfuscatedLiO::evaluate(x) == Circuit::evaluate(x)`
+//! - [OK] Real GGM-based PRF and SHA-256 PRG
+//! - [!] Wire labels are NOT real: uses `(a, b, LSB(wire_a), LSB(wire_b))` instead of
+//!   per-wire random λ-bit labels as required by the paper
+//! - [!] MACs are generated but NEVER verified during evaluation
+//! - [!] SEH digest is computed but NEVER used for consistency checks
+//! - [!] SmallObf (gate gadget iO) is NOT integrated
+//! - [!] PRF puncturing is implemented but NOT used
+//!
+//! ## What's Real vs. Stub
+//!
+//! | Component | Status | Notes |
+//! |-----------|--------|-------|
+//! | GGM PRF | Real | Standard textbook construction over SHA-256 PRG |
+//! | SHA-256 PRG | Real | H(seed ∥ ctr) expansion, RO model |
+//! | Wire encryption | Partial | PRF-masked truth tables, but wrong label structure |
+//! | MAC tags | Stub | Generated but never checked |
+//! | SEH | Stub | API exists, not enforced |
+//! | SmallObf | Stub | Not integrated into gate evaluation |
+
+use crate::circuit::{Circuit, Gate};
+use crate::crypto::{
+    GgmPrf, MacPrf, PuncturablePrf, Prg, SehDigest, SehParams, SehScheme, Sha256Prg, StubSeh,
+    StubSmallObf, WirePrf,
+};
+
+/// LiO parameters
+#[derive(Clone, Debug)]
+pub struct LiOParams {
+    /// Security parameter (bits)
+    pub lambda: usize,
+    /// Subcircuit size bound (s in the paper)
+    pub subcircuit_size: usize,
+    /// PRF tree depth for wire encryption
+    pub prf_depth: usize,
+}
+
+impl LiOParams {
+    /// Create new LiO parameters
+    pub fn new(lambda: usize, subcircuit_size: usize) -> Self {
+        let prf_depth = subcircuit_size * 2 + 8;
+        Self {
+            lambda,
+            subcircuit_size,
+            prf_depth,
+        }
+    }
+}
+
+impl Default for LiOParams {
+    fn default() -> Self {
+        Self::new(128, 8)
+    }
+}
+
+/// An obfuscated gate in the LiO construction
+#[derive(Clone, Debug)]
+pub struct ObfuscatedGate {
+    /// Encrypted truth table (4 entries for 2-input gate)
+    /// Each entry: (encrypted_output_label, mac_tag)
+    pub encrypted_table: Vec<([u8; 32], [u8; 32])>,
+    /// Gate index in the circuit
+    pub gate_index: usize,
+    /// Input wire indices
+    pub input_wires: (usize, usize),
+    /// Output wire index
+    pub output_wire: usize,
+}
+
+impl ObfuscatedGate {
+    /// Create a new obfuscated gate
+    pub fn new(
+        gate: &Gate,
+        gate_index: usize,
+        wire_prf: &WirePrf,
+        mac_prf: &MacPrf,
+        wire_prf_key: &[u8; 32],
+        mac_prf_key: &[u8; 32],
+    ) -> Self {
+        let mut encrypted_table = Vec::with_capacity(4);
+
+        for ab in 0..4u8 {
+            let a = (ab >> 0) & 1 == 1;
+            let b = (ab >> 1) & 1 == 1;
+            let output = gate.control_function.evaluate(a, b);
+
+            let input_label: Vec<bool> = vec![
+                a,
+                b,
+                (gate.input_wire_a as usize & 1) == 1,
+                (gate.input_wire_b as usize & 1) == 1,
+            ];
+
+            let _output_label: Vec<bool> = vec![output, (gate.output_wire as usize & 1) == 1];
+
+            let wire_mask = wire_prf.eval(wire_prf_key, &input_label);
+
+            let mut encrypted_output = [0u8; 32];
+            for i in 0..32 {
+                encrypted_output[i] = wire_mask[i] ^ if output { 0xFF } else { 0x00 };
+            }
+
+            let mac_key = mac_prf.eval(mac_prf_key, &input_label);
+            let prg = Sha256Prg;
+            let mac_tag_bytes = prg.expand(&mac_key, 32);
+            let mut mac_tag = [0u8; 32];
+            mac_tag.copy_from_slice(&mac_tag_bytes);
+
+            encrypted_table.push((encrypted_output, mac_tag));
+        }
+
+        Self {
+            encrypted_table,
+            gate_index,
+            input_wires: (gate.input_wire_a as usize, gate.input_wire_b as usize),
+            output_wire: gate.output_wire as usize,
+        }
+    }
+
+    /// Evaluate the obfuscated gate given input wire values
+    pub fn evaluate(
+        &self,
+        input_a: bool,
+        input_b: bool,
+        wire_prf: &WirePrf,
+        wire_prf_key: &[u8; 32],
+    ) -> bool {
+        let table_index = (input_a as usize) | ((input_b as usize) << 1);
+        let (encrypted_output, _mac_tag) = &self.encrypted_table[table_index];
+
+        let input_label: Vec<bool> = vec![
+            input_a,
+            input_b,
+            (self.input_wires.0 & 1) == 1,
+            (self.input_wires.1 & 1) == 1,
+        ];
+
+        let wire_mask = wire_prf.eval(wire_prf_key, &input_label);
+
+        let decrypted = encrypted_output[0] ^ wire_mask[0];
+
+        decrypted != 0
+    }
+}
+
+/// The result of LiO obfuscation
+#[derive(Clone, Debug)]
+pub struct ObfuscatedLiO {
+    /// Obfuscated gates
+    pub gates: Vec<ObfuscatedGate>,
+    /// Wire PRF key (in real impl, this would be distributed across gates)
+    pub wire_prf_key: [u8; 32],
+    /// MAC PRF key
+    pub mac_prf_key: [u8; 32],
+    /// PRF for wire encryption
+    pub wire_prf: WirePrf,
+    /// PRF for MAC generation
+    pub mac_prf: MacPrf,
+    /// Number of wires in the original circuit
+    pub num_wires: usize,
+    /// SEH digest for wire consistency
+    pub seh_digest: Option<SehDigest>,
+}
+
+impl ObfuscatedLiO {
+    /// Get the size of the obfuscated program in bytes
+    pub fn size_bytes(&self) -> usize {
+        let gate_size = 4 * 64;
+        let key_size = 64;
+        let seh_size = 32;
+
+        self.gates.len() * gate_size + key_size + seh_size
+    }
+
+    /// Evaluate the obfuscated program on input
+    pub fn evaluate(&self, input: usize) -> usize {
+        let mut wires = vec![false; self.num_wires];
+
+        for i in 0..self.num_wires {
+            wires[i] = (input >> i) & 1 == 1;
+        }
+
+        for gate in &self.gates {
+            let a = wires[gate.input_wires.0];
+            let b = wires[gate.input_wires.1];
+
+            let output = gate.evaluate(a, b, &self.wire_prf, &self.wire_prf_key);
+
+            wires[gate.output_wire] = output;
+        }
+
+        let mut output = 0usize;
+        for (i, &w) in wires.iter().enumerate() {
+            if w {
+                output |= 1 << i;
+            }
+        }
+        output
+    }
+}
+
+/// LiO obfuscator
+#[derive(Clone, Debug)]
+pub struct LiO {
+    /// Parameters
+    pub params: LiOParams,
+    /// Wire encryption PRF
+    wire_prf: WirePrf,
+    /// MAC PRF
+    mac_prf: MacPrf,
+    /// SEH scheme
+    seh: StubSeh,
+    /// Small-circuit obfuscator
+    #[allow(dead_code)]
+    small_obf: StubSmallObf,
+}
+
+impl LiO {
+    /// Create a new LiO obfuscator
+    pub fn new(params: LiOParams) -> Self {
+        let wire_prf = GgmPrf::new(params.prf_depth);
+        let mac_prf = GgmPrf::new(params.prf_depth);
+        let seh = StubSeh::new();
+        let small_obf = StubSmallObf;
+
+        Self {
+            params,
+            wire_prf,
+            mac_prf,
+            seh,
+            small_obf,
+        }
+    }
+
+    /// Obfuscate a circuit
+    pub fn obfuscate(&self, circuit: &Circuit) -> Result<ObfuscatedLiO, LiOError> {
+        if circuit.num_wires == 0 {
+            return Err(LiOError::InvalidCircuit(
+                "Circuit has no wires".to_string(),
+            ));
+        }
+
+        let wire_prf_key = self.wire_prf.keygen();
+        let mac_prf_key = self.mac_prf.keygen();
+
+        let mut obfuscated_gates = Vec::with_capacity(circuit.gates.len());
+
+        for (idx, gate) in circuit.gates.iter().enumerate() {
+            let obf_gate = ObfuscatedGate::new(
+                gate,
+                idx,
+                &self.wire_prf,
+                &self.mac_prf,
+                &wire_prf_key,
+                &mac_prf_key,
+            );
+            obfuscated_gates.push(obf_gate);
+        }
+
+        let initial_wire_values: Vec<bool> = (0..circuit.num_wires).map(|_| false).collect();
+        let seh_params = SehParams {
+            num_elements: circuit.num_wires,
+            ..Default::default()
+        };
+        let (seh_digest, _ciphertexts) = self.seh.hash(&seh_params, &initial_wire_values);
+
+        Ok(ObfuscatedLiO {
+            gates: obfuscated_gates,
+            wire_prf_key,
+            mac_prf_key,
+            wire_prf: self.wire_prf.clone(),
+            mac_prf: self.mac_prf.clone(),
+            num_wires: circuit.num_wires,
+            seh_digest: Some(seh_digest),
+        })
+    }
+}
+
+/// Errors during LiO obfuscation
+#[derive(Clone, Debug)]
+pub enum LiOError {
+    /// Invalid circuit structure
+    InvalidCircuit(String),
+    /// Cryptographic operation failed
+    CryptoError(String),
+}
+
+impl std::fmt::Display for LiOError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidCircuit(s) => write!(f, "Invalid circuit: {}", s),
+            Self::CryptoError(s) => write!(f, "Crypto error: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for LiOError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::circuit::ControlFunction;
+
+    #[test]
+    fn test_lio_obfuscate_simple() {
+        let gates = vec![Gate::new(2, 0, 1, ControlFunction::And)];
+        let circuit = Circuit::new(gates, 3);
+
+        let lio = LiO::new(LiOParams::default());
+        let result = lio.obfuscate(&circuit);
+
+        assert!(result.is_ok());
+        let obf = result.unwrap();
+        assert_eq!(obf.gates.len(), 1);
+    }
+
+    #[test]
+    fn test_lio_evaluate_and() {
+        let gates = vec![Gate::new(2, 0, 1, ControlFunction::And)];
+        let circuit = Circuit::new(gates, 3);
+
+        let lio = LiO::new(LiOParams::default());
+        let obf = lio.obfuscate(&circuit).unwrap();
+
+        assert_eq!(obf.evaluate(0b11) & 0b100, 0b100);
+        assert_eq!(obf.evaluate(0b01) & 0b100, 0);
+        assert_eq!(obf.evaluate(0b10) & 0b100, 0);
+        assert_eq!(obf.evaluate(0b00) & 0b100, 0);
+    }
+
+    #[test]
+    fn test_lio_evaluate_xor() {
+        let gates = vec![Gate::new(2, 0, 1, ControlFunction::Xor)];
+        let circuit = Circuit::new(gates, 3);
+
+        let lio = LiO::new(LiOParams::default());
+        let obf = lio.obfuscate(&circuit).unwrap();
+
+        assert_eq!(obf.evaluate(0b11) & 0b100, 0);
+        assert_eq!(obf.evaluate(0b01) & 0b100, 0b100);
+        assert_eq!(obf.evaluate(0b10) & 0b100, 0b100);
+        assert_eq!(obf.evaluate(0b00) & 0b100, 0);
+    }
+
+    #[test]
+    fn test_lio_evaluate_complex() {
+        let gates = vec![
+            Gate::new(2, 0, 1, ControlFunction::And),
+            Gate::new(3, 2, 0, ControlFunction::Xor),
+        ];
+        let circuit = Circuit::new(gates, 4);
+
+        let lio = LiO::new(LiOParams::default());
+        let obf = lio.obfuscate(&circuit).unwrap();
+
+        for input in 0..4 {
+            let expected = circuit.evaluate(input);
+            let actual = obf.evaluate(input);
+            assert_eq!(actual, expected, "Mismatch for input {}", input);
+        }
+    }
+
+    #[test]
+    fn test_lio_random_circuit() {
+        let circuit = Circuit::random_r57(4, 5);
+
+        let lio = LiO::new(LiOParams::default());
+        let obf = lio.obfuscate(&circuit).unwrap();
+
+        for input in 0..16 {
+            let expected = circuit.evaluate(input);
+            let actual = obf.evaluate(input);
+            assert_eq!(actual, expected, "Mismatch for input {}", input);
+        }
+    }
+}

--- a/src/padding.rs
+++ b/src/padding.rs
@@ -74,9 +74,9 @@ pub fn pad_single(circuit: &Circuit, n_bound: usize) -> Circuit {
     padded_gates.extend(copy_gates);
 
     while padded_gates.len() < n_bound {
-        let wire = (padded_gates.len() % num_wires) as u8;
-        let c1 = ((padded_gates.len() + 1) % num_wires) as u8;
-        let c2 = ((padded_gates.len() + 2) % num_wires) as u8;
+        let wire = (padded_gates.len() % num_wires) as u16;
+        let c1 = ((padded_gates.len() + 1) % num_wires) as u16;
+        let c2 = ((padded_gates.len() + 2) % num_wires) as u16;
 
         padded_gates.push(Gate::new(wire, c1, c2, ControlFunction::Xor));
         if padded_gates.len() < n_bound {
@@ -99,9 +99,9 @@ fn create_routing_network(num_wires: usize, depth: usize, start_idx: usize) -> V
     for level in 0..depth {
         let stride = 1 << level;
         for i in 0..(num_wires / (2 * stride)).max(1) {
-            let a = ((i * 2 * stride) % num_wires) as u8;
-            let b = (((i * 2 + 1) * stride) % num_wires) as u8;
-            let out = ((i * stride + start_idx + level) % num_wires) as u8;
+            let a = ((i * 2 * stride) % num_wires) as u16;
+            let b = (((i * 2 + 1) * stride) % num_wires) as u16;
+            let out = ((i * stride + start_idx + level) % num_wires) as u16;
 
             gates.push(Gate::new(out, a, b, ControlFunction::Xor));
         }
@@ -116,9 +116,9 @@ fn create_copy_gadgets(num_wires: usize, depth: usize) -> Vec<Gate> {
 
     for level in 0..depth {
         for i in 0..num_wires.min(4) {
-            let src = i as u8;
-            let dst = ((i + level + 1) % num_wires) as u8;
-            let ctrl = ((i + level + 2) % num_wires) as u8;
+            let src = i as u16;
+            let dst = ((i + level + 1) % num_wires) as u16;
+            let ctrl = ((i + level + 2) % num_wires) as u16;
 
             gates.push(Gate::new(dst, src, ctrl, ControlFunction::Xor));
         }
@@ -133,16 +133,16 @@ fn create_identity_circuit(num_wires: usize, size: usize) -> Circuit {
     let num_wires = num_wires.max(4);
 
     for i in 0..(size / 2) {
-        let wire = (i % num_wires) as u8;
-        let c1 = ((i + 1) % num_wires) as u8;
-        let c2 = ((i + 2) % num_wires) as u8;
+        let wire = (i % num_wires) as u16;
+        let c1 = ((i + 1) % num_wires) as u16;
+        let c2 = ((i + 2) % num_wires) as u16;
 
         gates.push(Gate::new(wire, c1, c2, ControlFunction::Xor));
         gates.push(Gate::new(wire, c1, c2, ControlFunction::Xor));
     }
 
     if size % 2 == 1 {
-        let wire = ((size / 2) % num_wires) as u8;
+        let wire = ((size / 2) % num_wires) as u16;
         gates.push(Gate::new(wire, wire, wire, ControlFunction::F));
     }
 
@@ -162,9 +162,9 @@ fn create_and_tree(num_outputs: usize, num_wires: usize) -> Vec<Gate> {
     for level in 0..depth {
         let pairs = (num_outputs >> level).max(1) / 2;
         for i in 0..pairs {
-            let a = (i * 2 % num_wires) as u8;
-            let b = ((i * 2 + 1) % num_wires) as u8;
-            let out = ((num_wires - 1 - level - i) % num_wires) as u8;
+            let a = (i * 2 % num_wires) as u16;
+            let b = ((i * 2 + 1) % num_wires) as u16;
+            let out = ((num_wires - 1 - level - i) % num_wires) as u16;
 
             gates.push(Gate::new(out, a, b, ControlFunction::And));
         }

--- a/src/padding.rs
+++ b/src/padding.rs
@@ -1,0 +1,311 @@
+//! Circuit padding for Ma-Dai-Shi iO
+//!
+//! Implements the padding construction from §3.2 of the paper.
+//! Padding converts arbitrary circuits to a fixed topology, ensuring that
+//! equivalent circuits become transitively s-equivalent for s = O(log N).
+//!
+//! ## Construction
+//!
+//! 1. **PadSingle(C, N)**: Convert circuit C to fixed topology of size O(N)
+//!    - Topologically sort gates
+//!    - Add routing network with binary tree selectors
+//!    - Add copy gadgets for wire fan-out
+//!
+//! 2. **Pad(C, N_circ, N_proof)**: Full padding
+//!    - C1 = PadSingle(C, N_circ)
+//!    - C2 = PadSingle(identity, N_circ)
+//!    - C_proof = PadSingle(identity, c*(N_circ + N_proof))
+//!    - Combine with AND-tree
+
+use crate::circuit::{Circuit, ControlFunction, Gate};
+
+/// Result of padding a circuit
+#[derive(Clone, Debug)]
+pub struct PaddedCircuit {
+    /// The main (original) circuit, padded
+    pub main_circuit: Circuit,
+    /// Filler circuit (identity operations)
+    pub filler_circuit: Circuit,
+    /// Proof encoding circuit
+    pub proof_circuit: Circuit,
+    /// AND-tree combining the circuits
+    pub and_tree: Vec<Gate>,
+    /// Combined circuit (main + filler + proof + AND-tree)
+    pub combined: Circuit,
+    /// Original circuit size
+    pub original_size: usize,
+    /// Padding overhead information
+    pub overhead: PaddingOverhead,
+}
+
+/// Information about padding overhead
+#[derive(Clone, Debug)]
+pub struct PaddingOverhead {
+    /// Number of gates in original circuit
+    pub original_gates: usize,
+    /// Number of gates after padding
+    pub padded_gates: usize,
+    /// Number of routing gates added
+    pub routing_gates: usize,
+    /// Number of AND-tree gates added
+    pub and_tree_gates: usize,
+    /// Size ratio (padded / original)
+    pub size_ratio: f64,
+}
+
+/// Pad a single circuit to a fixed size
+///
+/// Adds routing network and identity operations to reach the target size.
+pub fn pad_single(circuit: &Circuit, n_bound: usize) -> Circuit {
+    if circuit.gates.is_empty() {
+        return create_identity_circuit(circuit.num_wires, n_bound);
+    }
+
+    let mut padded_gates = Vec::new();
+    let num_wires = circuit.num_wires.max(4);
+
+    padded_gates.extend(circuit.gates.iter().cloned());
+
+    let routing_depth = ((n_bound as f64).log2().ceil() as usize).max(1);
+    let routing_gates = create_routing_network(num_wires, routing_depth, padded_gates.len());
+    padded_gates.extend(routing_gates);
+
+    let copy_gates = create_copy_gadgets(num_wires, routing_depth);
+    padded_gates.extend(copy_gates);
+
+    while padded_gates.len() < n_bound {
+        let wire = (padded_gates.len() % num_wires) as u8;
+        let c1 = ((padded_gates.len() + 1) % num_wires) as u8;
+        let c2 = ((padded_gates.len() + 2) % num_wires) as u8;
+
+        padded_gates.push(Gate::new(wire, c1, c2, ControlFunction::Xor));
+        if padded_gates.len() < n_bound {
+            padded_gates.push(Gate::new(wire, c1, c2, ControlFunction::Xor));
+        }
+    }
+
+    padded_gates.truncate(n_bound);
+
+    Circuit {
+        gates: padded_gates,
+        num_wires,
+    }
+}
+
+/// Create a routing network for wire permutation
+fn create_routing_network(num_wires: usize, depth: usize, start_idx: usize) -> Vec<Gate> {
+    let mut gates = Vec::new();
+
+    for level in 0..depth {
+        let stride = 1 << level;
+        for i in 0..(num_wires / (2 * stride)).max(1) {
+            let a = ((i * 2 * stride) % num_wires) as u8;
+            let b = (((i * 2 + 1) * stride) % num_wires) as u8;
+            let out = ((i * stride + start_idx + level) % num_wires) as u8;
+
+            gates.push(Gate::new(out, a, b, ControlFunction::Xor));
+        }
+    }
+
+    gates
+}
+
+/// Create copy gadgets for wire fan-out
+fn create_copy_gadgets(num_wires: usize, depth: usize) -> Vec<Gate> {
+    let mut gates = Vec::new();
+
+    for level in 0..depth {
+        for i in 0..num_wires.min(4) {
+            let src = i as u8;
+            let dst = ((i + level + 1) % num_wires) as u8;
+            let ctrl = ((i + level + 2) % num_wires) as u8;
+
+            gates.push(Gate::new(dst, src, ctrl, ControlFunction::Xor));
+        }
+    }
+
+    gates
+}
+
+/// Create an identity circuit of a given size
+fn create_identity_circuit(num_wires: usize, size: usize) -> Circuit {
+    let mut gates = Vec::with_capacity(size);
+    let num_wires = num_wires.max(4);
+
+    for i in 0..(size / 2) {
+        let wire = (i % num_wires) as u8;
+        let c1 = ((i + 1) % num_wires) as u8;
+        let c2 = ((i + 2) % num_wires) as u8;
+
+        gates.push(Gate::new(wire, c1, c2, ControlFunction::Xor));
+        gates.push(Gate::new(wire, c1, c2, ControlFunction::Xor));
+    }
+
+    if size % 2 == 1 {
+        let wire = ((size / 2) % num_wires) as u8;
+        gates.push(Gate::new(wire, wire, wire, ControlFunction::F));
+    }
+
+    Circuit { gates, num_wires }
+}
+
+/// Create an AND-tree combining multiple outputs
+fn create_and_tree(num_outputs: usize, num_wires: usize) -> Vec<Gate> {
+    let mut gates = Vec::new();
+
+    if num_outputs <= 1 {
+        return gates;
+    }
+
+    let depth = ((num_outputs as f64).log2().ceil() as usize).max(1);
+
+    for level in 0..depth {
+        let pairs = (num_outputs >> level).max(1) / 2;
+        for i in 0..pairs {
+            let a = (i * 2 % num_wires) as u8;
+            let b = ((i * 2 + 1) % num_wires) as u8;
+            let out = ((num_wires - 1 - level - i) % num_wires) as u8;
+
+            gates.push(Gate::new(out, a, b, ControlFunction::And));
+        }
+    }
+
+    gates
+}
+
+/// Full padding construction per §3.2.2
+///
+/// Creates: C1 (main) + C2 (filler) + C_proof + AND-tree
+pub fn pad(circuit: &Circuit, n_circ: usize, n_proof: usize) -> PaddedCircuit {
+    let num_wires = circuit.num_wires.max(8);
+    let original_size = circuit.gates.len();
+
+    let main_circuit = pad_single(circuit, n_circ);
+    let filler_circuit = create_identity_circuit(num_wires, n_circ);
+
+    let c = 2;
+    let proof_size = c * (n_circ + n_proof);
+    let proof_circuit = create_identity_circuit(num_wires, proof_size.min(n_circ * 4));
+
+    let and_tree = create_and_tree(3, num_wires);
+
+    let mut combined_gates = Vec::new();
+    combined_gates.extend(main_circuit.gates.iter().cloned());
+    combined_gates.extend(filler_circuit.gates.iter().cloned());
+    combined_gates.extend(proof_circuit.gates.iter().cloned());
+    combined_gates.extend(and_tree.iter().cloned());
+
+    let padded_gates = combined_gates.len();
+    let routing_gates = main_circuit.gates.len().saturating_sub(original_size);
+
+    let combined = Circuit {
+        gates: combined_gates,
+        num_wires,
+    };
+
+    PaddedCircuit {
+        main_circuit,
+        filler_circuit,
+        proof_circuit,
+        and_tree: and_tree.clone(),
+        combined,
+        original_size,
+        overhead: PaddingOverhead {
+            original_gates: original_size,
+            padded_gates,
+            routing_gates,
+            and_tree_gates: and_tree.len(),
+            size_ratio: padded_gates as f64 / original_size.max(1) as f64,
+        },
+    }
+}
+
+/// Optimized padding with minimal overhead
+///
+/// Uses a simpler padding strategy for cases where full security is not needed.
+pub fn pad_optimized(circuit: &Circuit) -> PaddedCircuit {
+    let num_wires = circuit.num_wires.max(4);
+    let original_size = circuit.gates.len();
+
+    let target_size = original_size + ((original_size as f64).log2().ceil() as usize).max(4) * 2;
+    let main_circuit = pad_single(circuit, target_size);
+
+    let filler_circuit = Circuit {
+        gates: vec![],
+        num_wires,
+    };
+    let proof_circuit = Circuit {
+        gates: vec![],
+        num_wires,
+    };
+    let and_tree = vec![];
+
+    let padded_gates = main_circuit.gates.len();
+    let routing_gates = padded_gates.saturating_sub(original_size);
+
+    PaddedCircuit {
+        main_circuit: main_circuit.clone(),
+        filler_circuit,
+        proof_circuit,
+        and_tree,
+        combined: main_circuit,
+        original_size,
+        overhead: PaddingOverhead {
+            original_gates: original_size,
+            padded_gates,
+            routing_gates,
+            and_tree_gates: 0,
+            size_ratio: padded_gates as f64 / original_size.max(1) as f64,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pad_single() {
+        let circuit = Circuit::random_r57(8, 10);
+        let padded = pad_single(&circuit, 32);
+
+        assert_eq!(padded.gates.len(), 32);
+        assert!(padded.num_wires >= circuit.num_wires);
+    }
+
+    #[test]
+    fn test_pad_single_empty() {
+        let circuit = Circuit::identity(4);
+        let padded = pad_single(&circuit, 16);
+
+        assert_eq!(padded.gates.len(), 16);
+    }
+
+    #[test]
+    fn test_full_padding() {
+        let circuit = Circuit::random_r57(6, 10);
+        let padded = pad(&circuit, 20, 100);
+
+        assert!(padded.combined.gates.len() > circuit.gates.len());
+        assert_eq!(padded.original_size, 10);
+        assert!(padded.overhead.size_ratio > 1.0);
+    }
+
+    #[test]
+    fn test_optimized_padding() {
+        let circuit = Circuit::random_r57(6, 10);
+        let padded = pad_optimized(&circuit);
+
+        assert!(padded.combined.gates.len() >= circuit.gates.len());
+        assert!(padded.filler_circuit.gates.is_empty());
+        assert!(padded.proof_circuit.gates.is_empty());
+    }
+
+    #[test]
+    fn test_identity_circuit() {
+        let identity = create_identity_circuit(4, 10);
+
+        assert!(identity.gates.len() >= 10);
+        assert!(identity.num_wires >= 4);
+    }
+}


### PR DESCRIPTION
## Summary

Replace monolithic stub module with modular architecture featuring real cryptographic primitives for the Ma-Dai-Shi quasi-linear iO construction.

## What Changed

### New Module Structure
| File | Description |
|------|-------------|
| `src/circuit.rs` | Circuit/Gate/ControlFunction with evaluation |
| `src/crypto/fhe.rs` | FHE trait with StubFhe placeholder |
| `src/crypto/prf.rs` | GGM-based Puncturable PRF (**real crypto**) |
| `src/crypto/prg.rs` | SHA-256 based PRG (**real crypto**) |
| `src/crypto/seh.rs` | Somewhere Extractable Hash trait with StubSeh |
| `src/crypto/obf.rs` | Small-circuit iO trait (documented assumption) |
| `src/lio.rs` | Local iO with PRF-based wire encryption |
| `src/padding.rs` | Circuit padding with routing networks |

### Real Cryptographic Implementations
- **GGM PRF**: Standard textbook construction over SHA-256 PRG
- **SHA-256 PRG**: H(seed || ctr) expansion in RO model  
- **Puncturable PRF**: Full puncture/eval_punctured support for security reductions

### Security Status

Current LiO provides **functional correctness** but NOT full security:

| Component | Status | Notes |
|-----------|--------|-------|
| GGM PRF | [OK] Real | Standard textbook construction |
| SHA-256 PRG | [OK] Real | H(seed∥ctr) expansion, RO model |
| Wire encryption | [!] Partial | PRF-masked truth tables, but simplified labels |
| MAC tags | [!] Stub | Generated but never checked |
| SEH | [!] Stub | API exists, not enforced |
| SmallObf | [!] Stub | Not integrated into gate evaluation |

### Test Results
- 34 unit tests pass
- 7 integration tests pass
- LiO correctly evaluates random circuits

## Oracle Review

Reviewed by oracle - confirmed:
- No hallucinated crypto constructions
- GGM PRF and SHA-256 PRG are standard and correct
- All incomplete parts are clearly documented

## Next Steps (Milestones 2-4)
- Milestone 2: Integrate LWE-based FHE (`tfhe` crate) and complete SEH
- Milestone 3: Parameter discipline & security documentation
- Milestone 4: Document small-circuit iO as explicit assumption

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces stub monolith with modular core/crypto, implements LiO and padding, introduces real GGM PRF and SHA-256 PRG, and updates integration/tests.
> 
> - **Core**:
>   - Add `src/circuit.rs` (gates/circuits with eval/random) and `src/padding.rs` (padding: `pad`, `pad_single`, `pad_optimized`).
>   - Rewrite `src/lib.rs` to expose modules, params, obfuscation API (`obfuscate*`, `estimate_overhead*`), metrics, hybrid utilities, and `compat::proven_stealth_mix`.
> - **Crypto**:
>   - New `src/crypto/` with traits/impls: `prg.rs` (SHA-256 PRG), `prf.rs` (GGM puncturable PRF), `fhe.rs` (FHE trait + `StubFhe`), `seh.rs` (SEH over ciphertexts, stub), `obf.rs` (small-circuit iO trait + stubs).
> - **LiO**:
>   - Add `src/lio.rs`: LiO obfuscation with PRF-based wire encryption, MAC generation (stubbed verification), SEH digest, evaluation, and sizing.
> - **Examples/Tests**:
>   - Update `examples/integration_test.rs` to use `compat::proven_stealth_mix` and new API; add comprehensive unit tests in new modules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23e277ec2277cea301f02982cdec163e4ead8525. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full modular obfuscation stack: per-wire labels, per-gate obfuscation, SEH with Merkle-based openings and prefix-consistency proofs, puncturable PRF support, optional FHE backend selectable via feature, and padding/hybrid-sequence tooling.
* **Bug Fixes / Error Handling**
  * Evaluation now returns explicit errors instead of panicking for verification/MAC/label failures.
* **Tests**
  * Extensive unit/integration tests added and Criterion benchmarks for obfuscation and evaluation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->